### PR TITLE
Include interaction hints in action responses

### DIFF
--- a/app/api/actions.py
+++ b/app/api/actions.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from flask import Blueprint, request, jsonify
 from server.player_engine import Player  # type hints
 from server.actionRegistry import get_action
-from server.services import idempotency, cooldowns
+from server.services import idempotency, cooldowns, rooms
 
 # Import handlers so decorators run
 from server.actions import *  # noqa: F401,F403
@@ -17,7 +17,7 @@ from server.actions import *  # noqa: F401,F403
 bp = Blueprint("actions_api", __name__, url_prefix="/api")
 
 # Replace with your real player accessor; consistent with app/api/routes.py singletons:
-from app.api.routes import PLAYER as CURRENT_PLAYER  # reuse the same player singleton
+from app.api.routes import PLAYER as CURRENT_PLAYER, _interactions  # reuse the same player singleton
 
 @bp.post("/action")
 def do_action():
@@ -49,6 +49,15 @@ def do_action():
         result = handler(player=player, payload=payload)
     except Exception as e:
         return jsonify({"ok": False, "error":"server_exception", "detail": str(e)}), 500
+
+    # append interaction hints for the player's current room
+    try:
+        room = rooms.for_player(player)
+        room_data = room.export()
+        result["interactions"] = _interactions(room_data)
+    except Exception:
+        # don't block action result if room lookup fails
+        pass
 
     idempotency.persist(player.id, action_id, verb, payload, result)
     return jsonify(result), 200

--- a/static/js/actionHud.js
+++ b/static/js/actionHud.js
@@ -139,9 +139,10 @@ async function doMove(dir) {
 }
 
 async function doAction(verb, payload = {}) {
+  let out;
   try {
     setBusy(true);
-    const out = await API.action(verb, payload);
+    out = await API.action(verb, payload);
     if (out?.events?.length) window.dispatchEvent(new CustomEvent("game:log", { detail: out.events }));
     if (out?.room_delta) window.patchRoom?.(out.room_delta);
   } catch (err) {
@@ -149,8 +150,7 @@ async function doAction(verb, payload = {}) {
     console.error(err);
   } finally {
     setBusy(false);
-    const st = await API.state();
-    updateActionHUD({ interactions: st.interactions });
+    if (out?.interactions) updateActionHUD({ interactions: out.interactions });
   }
 }
 


### PR DESCRIPTION
## Summary
- Append interaction hints to action API responses using current room data
- Remove redundant API.state call in action HUD and consume interaction hints from action responses

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af41d9f978832d9dae03d677dd6111