### PR TITLE
Refactor to session-backed player retrieval

### DIFF
--- a/app/api/actions.py
+++ b/app/api/actions.py
@@ -16,12 +16,11 @@ from server.actions import *  # noqa: F401,F403
 
 bp = Blueprint("actions_api", __name__, url_prefix="/api")
 
-# Replace with your real player accessor; consistent with app/api/routes.py singletons:
-from app.api.routes import PLAYER as CURRENT_PLAYER  # reuse the same player singleton
+from app.player_service import get_player, save_player
 
 @bp.post("/action")
 def do_action():
-    player = CURRENT_PLAYER  # (later: get from session)
+    player = get_player()
     if not isinstance(player, Player):
         return jsonify({"error": "unauthorized"}), 401
 
@@ -51,4 +50,5 @@ def do_action():
         return jsonify({"ok": False, "error":"server_exception", "detail": str(e)}), 500
 
     idempotency.persist(player.id, action_id, verb, payload, result)
+    save_player(player)
     return jsonify(result), 200

--- a/app/player_service.py
+++ b/app/player_service.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+"""Player lookup/creation helpers.
+
+Stores a serialized ``Player`` in the Flask session and rebuilds it on
+subsequent requests.  This replaces the old module-level singleton pattern.
+"""
+
+from typing import Dict
+from flask import session
+
+from server.player_engine import Player, QuestState
+
+
+def _deserialize(data: Dict) -> Player:
+    """Rebuild a :class:`Player` instance from session data."""
+    player = Player()
+    for key, value in data.items():
+        if key == "quests_active":
+            player.quests_active = {k: QuestState(**v) for k, v in value.items()}
+        elif key == "quests_done":
+            player.quests_done = set(value)
+        else:
+            setattr(player, key, value)
+    return player
+
+
+def get_player() -> Player:
+    """Return the current player, creating one if necessary."""
+    data = session.get("player")
+    if data:
+        return _deserialize(data)
+    player = Player()
+    session["player"] = player.as_public()
+    return player
+
+
+def save_player(player: Player) -> None:
+    """Persist the player's state back to the session."""
+    session["player"] = player.as_public()


### PR DESCRIPTION
## Summary
- replace global PLAYER singleton with session-backed lookup
- add `player_service` module for loading and saving players
- update game and action endpoints to use the new helpers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af41d01024832d8916057da000ea39