### PR TITLE
Add API route tests and fix app factory configuration

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,9 +7,11 @@ def create_app():
     app = Flask(__name__, static_folder="../static", template_folder="../templates")
 
     # Minimal config; adjust later
-    app.config.setdefault("SECRET_KEY", "dev")
-    app.config.setdefault("SQLALCHEMY_DATABASE_URI", "sqlite:///app.db")
-    app.config.setdefault("SQLALCHEMY_TRACK_MODIFICATIONS", False)
+    app.config.update(
+        SECRET_KEY="dev",
+        SQLALCHEMY_DATABASE_URI="sqlite:///app.db",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+    )
 
     # Extensions
     db.init_app(app)
@@ -21,6 +23,6 @@ def create_app():
 
     # Ensure models are imported so migrations see them
     with app.app_context():
-        import app.models  # noqa: F401
+        from . import models  # noqa: F401
 
     return app

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -1,0 +1,20 @@
+from app import create_app
+
+
+def test_spawn_and_move_updates_state():
+    app = create_app()
+    with app.test_client() as client:
+        # Spawn the player and ensure basic payload pieces exist
+        resp = client.post('/api/spawn', json={})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert {'player', 'room', 'interactions'} <= data.keys()
+        start_pos = data['player']['pos']
+        start_interactions = data['interactions']
+
+        # Move the player one tile to the right
+        move = client.post('/api/move', json={'dx': 1, 'dy': 0})
+        assert move.status_code == 200
+        move_data = move.get_json()
+        assert move_data['player']['pos'] == [start_pos[0] + 1, start_pos[1]]
+        assert move_data['interactions'] != start_interactions


### PR DESCRIPTION
## Summary
- Ensure `create_app` sets required config values and imports models without shadowing the app object
- Add tests for `/api/spawn` and `/api/move` verifying player state and interaction payloads

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af45fb1800832d91ac88e90fb447b9