### PR TITLE
Implement room combat and basic delivery quest

### DIFF
--- a/server/actions/__init__.py
+++ b/server/actions/__init__.py
@@ -3,3 +3,4 @@
 from . import search  # noqa: F401
 from . import gather  # noqa: F401
 from . import attack  # noqa: F401
+from . import talk    # noqa: F401

--- a/server/actions/attack.py
+++ b/server/actions/attack.py
@@ -16,11 +16,7 @@ def attack(*, player, payload: dict) -> dict:
     if hasattr(combat_mod, "resolve_round"):
         result = combat_mod.resolve_round(player, target_id)
     else:
-        result = {"events":[{"type":"log","text":f"You strike {target_id} (stub)."}]}
-
-    defeated_ids = set(result.get("defeated_ids", []))
-    if defeated_ids:
-        room_obj.enemies = [e for e in room_obj.enemies if e.get("id") not in defeated_ids]
+        result = {"events": [{"type": "log", "text": f"You strike {target_id} (stub)."}], "defeated_ids": []}
 
     result.setdefault("player", player.as_public())
     result.setdefault("room_delta", {"enemies": room_obj.enemies})

--- a/server/actions/talk.py
+++ b/server/actions/talk.py
@@ -1,0 +1,40 @@
+from server.actionRegistry import action
+from server.services.rooms import for_player
+from server.player_engine import QuestState
+
+
+@action("talk")
+def talk(*, player, payload: dict) -> dict:
+    target_id = payload.get("target_id")
+    if not target_id:
+        return {"ok": False, "events": [{"type": "log", "text": "No target."}]}
+
+    room_obj = for_player(player)
+    npc = next((n for n in room_obj.npcs if n.get("id") == target_id), None)
+    if not npc:
+        return {"ok": False, "events": [{"type": "log", "text": "No one by that name here."}]}
+
+    log: list[str] = []
+    quest_id = npc.get("gives_quest")
+    if quest_id == "LETTER_QUEST":
+        if quest_id not in player.quests_active and quest_id not in player.quests_done:
+            player.quests_active[quest_id] = QuestState(id=quest_id, data={"target": (14, 9)})
+            log.append("Villager: Please deliver this letter to the harbormaster in the port village north of here.")
+        else:
+            log.append("Villager: Thank you again for helping out.")
+    elif npc.get("accepts_quest") == "LETTER_QUEST":
+        q = player.quests_active.get("LETTER_QUEST")
+        if q and q.status == "active":
+            q.status = "complete"
+            player.quests_done.add(q.id)
+            player.quests_active.pop(q.id, None)
+            player.gold += 10
+            player.xp += 20
+            log.append("Harbormaster: Ah, a letter for me? Thank you! (Quest complete)")
+        else:
+            log.append("Harbormaster: Safe travels, adventurer.")
+    else:
+        name = npc.get("name", "Someone")
+        log.append(f"{name}: Hello there.")
+
+    return {"ok": True, "events": [{"type": "log", "text": m} for m in log], "player": player.as_public()}

--- a/server/combat.py
+++ b/server/combat.py
@@ -1,5 +1,6 @@
 # server/combat.py
 import random
+import time
 
 ENEMIES = {
     "plains":[{"id":"bandit","hp":12,"atk":4,"def":1,"spd":3}],
@@ -39,3 +40,36 @@ def resolve_combat(player, enemy) -> list[str]:
     else:
         log.append("You were defeated…")
     return log
+
+
+def resolve_round(player, target_id: str) -> dict:
+    """Resolve a single round of combat against an enemy in the current room."""
+    from server.services.rooms import for_player
+
+    room = for_player(player)
+    enemy = next((e for e in room.enemies if e.get("id") == target_id), None)
+    if not enemy or enemy.get("hp_now", enemy.get("hp", 0)) <= 0:
+        return {"events": [{"type": "log", "text": "No target."}], "defeated_ids": []}
+
+    log: list[str] = []
+    php = player.hp
+    ehp = enemy.get("hp_now", enemy.get("hp", 0))
+
+    # player strikes first
+    ehp -= max(1, 3 - enemy.get("def", 0))
+    log.append(f"You hit {enemy['id']}. ({max(ehp,0)} HP left)")
+    if ehp <= 0:
+        enemy["hp_now"] = 0
+        enemy["defeated_at"] = time.time()
+        player.xp += 10
+        log.append(f"You defeated the {enemy['id']}!")
+        return {"events": [{"type": "log", "text": m} for m in log], "defeated_ids": [enemy["id"]], "player": player.as_public()}
+
+    # enemy counter-attack
+    php -= max(1, enemy.get("atk", 1) - 1)
+    player.hp = max(0, php)
+    enemy["hp_now"] = ehp
+    log.append(f"{enemy['id']} hits you. ({player.hp} HP left)")
+    if player.hp <= 0:
+        log.append("You were defeated…")
+    return {"events": [{"type": "log", "text": m} for m in log], "defeated_ids": [] , "player": player.as_public()}

--- a/server/game_state.py
+++ b/server/game_state.py
@@ -1,6 +1,6 @@
 # server/game_state.py
 from pathlib import Path
-from .world_loader import load_world
+from .world_loader import load_world, add_safe_zone
 from .player_engine import Player
 
 # Default shard (match your current path)
@@ -8,3 +8,8 @@ STARTER_SHARD_PATH = Path("static/public/shards/00089451_test123.json")
 
 WORLD = load_world(STARTER_SHARD_PATH)
 PLAYER = Player()
+# starter spawn position within the town
+PLAYER.spawn(12, 15)
+add_safe_zone(12, 15)
+add_safe_zone(13, 15)  # NPC tile
+WORLD.pois.append({"x": 12, "y": 15, "type": "town"})


### PR DESCRIPTION
## Summary
- add safe zone support and enemy respawn controls in world loader
- spawn player in starter town with NPC quest to deliver a letter north
- extend API interactions and add talk action with room-based combat rounds

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af869fb564832d9a2d2e9935b8b40b