### PR TITLE
Handle site-flavored settlements

### DIFF
--- a/server/world_loader.py
+++ b/server/world_loader.py
@@ -139,7 +139,19 @@ _CURRENT_WORLD: Optional[World] = None  # optional singleton for legacy helpers
 def load_world(path: str | Path) -> World:
     data = json.loads(Path(path).read_text())
 
-    grid = data["grid"]  # fast access heatmap
+    grid = data.get("grid")
+    if not grid and "tiles" in data:
+        tiles = data["tiles"]
+        grid = []
+        for row in tiles:
+            line = []
+            for cell in row:
+                if isinstance(cell, dict):
+                    val = cell.get("tile") or cell.get("biome") or cell.get("type") or cell.get("tag")
+                else:
+                    val = cell
+                line.append(str(val))
+            grid.append(line)
     H = len(grid)
     W = len(grid[0]) if H else 0
 

--- a/shardEngine/persistence.py
+++ b/shardEngine/persistence.py
@@ -37,8 +37,8 @@ def _format_filename(seed: int, base_name: str) -> str:
     return f"{int(seed):08d}_{_safe_name(base_name)}.json"
 
 def _grid_to_legacy_tiles(grid: List[List[str]]) -> List[List[Dict[str, str]]]:
-    # legacy shape v1 viewers expect: tiles[y][x] = {"biome": "<id>"}
-    return [[{"biome": cell} for cell in row] for row in grid]
+    # legacy shape v1 viewers expect: tiles[y][x] = {"tile": "<id>"}
+    return [[{"tile": cell} for cell in row] for row in grid]
 
 def _sites_to_legacy_pois(sites: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     # legacy POIs are shallow dicts; keep v2 fields where possible

--- a/static/js/movement/movementRules.js
+++ b/static/js/movement/movementRules.js
@@ -30,9 +30,9 @@ export function createMovementRules(shard) {
   const IMPASSABLE = new Set(["Mountains", "Volcano"]);
 
   const biomeAt = (x, y) => {
-    if (!shard?.grid) return "Forest";
+    if (!shard?.tiles) return "Forest";
     if (x < 0 || y < 0 || x >= W || y >= H) return "void";
-    return shard.grid[y][x];
+    return shard.tiles[y][x];
   };
   const key = (x, y) => `${x},${y}`;
   const onRoad   = (x, y) => roadSet.has(key(x, y));

--- a/static/js/shard-viewer-v2.js
+++ b/static/js/shard-viewer-v2.js
@@ -135,6 +135,7 @@
       for (let x=0; x<row.length; x++) {
         const cell = row[x];
         if (typeof cell === "string") line[x] = cell;
+        else if (cell && typeof cell.tile  === "string") line[x] = cell.tile;
         else if (cell && typeof cell.biome === "string") line[x] = cell.biome;
         else if (cell && typeof cell.type  === "string") line[x] = cell.type;
         else if (cell && typeof cell.tag   === "string") line[x] = cell.tag;

--- a/static/js/shard-viewer.js
+++ b/static/js/shard-viewer.js
@@ -92,7 +92,7 @@ function normalize(json){
     tiles = json.grid.map(row => row.map(b => ({ biome: canonBiome(b) })));
   } else if (Array.isArray(json.tiles)) {
     tiles = json.tiles.map(row => row.map(cell => {
-      const b = typeof cell === 'string' ? cell : (cell?.biome || cell?.type || cell?.tag);
+      const b = typeof cell === 'string' ? cell : (cell?.tile || cell?.biome || cell?.type || cell?.tag);
       return { ...cell, biome: canonBiome(b) };
     }));
   } else {

--- a/static/public/shards/00089451_test123.json
+++ b/static/public/shards/00089451_test123.json
@@ -13,818 +13,822 @@
   "tiles": [
     [
       {
-        "biome": "plains"
+        "tile": "plains"
       },
       {
-        "biome": "plains"
+        "tile": "plains"
       },
       {
-        "biome": "plains"
+        "tile": "plains"
       },
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       }
     ],
     [
       {
-        "biome": "forest"
+        "tile": "forest"
       },
       {
-        "biome": "plains"
+        "tile": "plains"
       },
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       }
     ],
     [
       {
-        "biome": "plains"
+        "tile": "plains"
       },
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       }
     ],
     [
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       }
     ],
     [
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       }
     ],
     [
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       }
     ],
     [
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       }
     ],
     [
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       }
     ],
     [
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       }
     ],
     [
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "forest"
+        "tile": "forest"
       },
       {
-        "biome": "forest"
+        "tile": "forest"
       },
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
         "site": {
           "type": "port",
           "name": "Test Port",
           "flavor": "Ships sway at the port. ENTER to visit the docks."
-        }
+        },
+        "tile": "port"
       },
       {
-        "biome": "coast"
+        "tile": "coast"
       }
     ],
     [
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "plains"
+        "tile": "plains"
       },
       {
-        "biome": "marsh-lite"
+        "tile": "marsh-lite"
       },
       {
-        "biome": "plains"
+        "tile": "plains"
       },
       {
-        "biome": "plains"
+        "tile": "plains"
       },
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "plains"
+        "tile": "plains"
       },
       {
         "site": {
           "type": "city",
           "name": "Test City",
           "flavor": "The city walls rise ahead. Perhaps you should ENTER."
-        }
+        },
+        "tile": "city"
       }
     ],
     [
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "plains"
+        "tile": "plains"
       },
       {
-        "biome": "plains"
+        "tile": "plains"
       },
       {
-        "biome": "plains"
+        "tile": "plains"
       },
       {
-        "biome": "forest"
+        "tile": "forest"
       },
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
         "site": {
           "type": "town",
           "name": "Test Town",
           "flavor": "A modest town lies nearby. Maybe ENTER."
-        }
+        },
+        "tile": "town"
       },
       {
-        "biome": "plains"
+        "tile": "plains"
       },
       {
-        "biome": "marsh-lite"
+        "tile": "marsh-lite"
       },
       {
-        "biome": "forest"
+        "tile": "forest"
       },
       {
-        "biome": "forest"
+        "tile": "forest"
       }
     ],
     [
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "plains"
+        "tile": "plains"
       },
       {
-        "biome": "plains"
+        "tile": "plains"
       },
       {
-        "biome": "hills"
+        "tile": "hills"
       },
       {
-        "biome": "plains"
+        "tile": "plains"
       },
       {
-        "biome": "plains"
+        "tile": "plains"
       },
       {
-        "biome": "forest"
+        "tile": "forest"
       },
       {
-        "biome": "forest"
+        "tile": "forest"
       },
       {
-        "biome": "plains"
+        "tile": "plains"
       },
       {
-        "biome": "plains"
+        "tile": "plains"
       },
       {
-        "biome": "plains"
+        "tile": "plains"
       },
       {
-        "biome": "forest"
+        "tile": "forest"
       },
       {
-        "biome": "plains"
+        "tile": "plains"
       }
     ],
     [
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "plains"
+        "tile": "plains"
       },
       {
-        "biome": "plains"
+        "tile": "plains"
       },
       {
-        "biome": "hills"
+        "tile": "hills"
       },
       {
-        "biome": "hills"
+        "tile": "hills"
       },
       {
-        "biome": "hills"
+        "tile": "hills"
       },
       {
-        "biome": "hills"
+        "tile": "hills"
       },
       {
-        "biome": "hills"
+        "tile": "hills"
       },
       {
-        "biome": "hills"
+        "tile": "hills"
       },
       {
-        "biome": "plains"
+        "tile": "plains"
       },
       {
-        "biome": "forest"
+        "tile": "forest"
       },
       {
-        "biome": "plains"
+        "tile": "plains"
       },
       {
-        "biome": "plains"
+        "tile": "plains"
       }
     ],
     [
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "plains"
+        "tile": "plains"
       },
       {
-        "biome": "plains"
+        "tile": "plains"
       },
       {
-        "biome": "hills"
+        "tile": "hills"
       },
       {
-        "biome": "hills"
+        "tile": "hills"
       },
       {
-        "biome": "hills"
+        "tile": "hills"
       },
       {
-        "biome": "mountains"
+        "tile": "mountains"
       },
       {
-        "biome": "hills"
+        "tile": "hills"
       },
       {
-        "biome": "hills"
+        "tile": "hills"
       },
       {
-        "biome": "plains"
+        "tile": "plains"
       },
       {
-        "biome": "plains"
+        "tile": "plains"
       },
       {
-        "biome": "plains"
+        "tile": "plains"
       },
       {
-        "biome": "forest"
+        "tile": "forest"
       }
     ],
     [
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "ocean"
+        "tile": "ocean"
       },
       {
-        "biome": "coast"
+        "tile": "coast"
       },
       {
-        "biome": "plains"
+        "tile": "plains"
       },
       {
-        "biome": "plains"
+        "tile": "plains"
       },
       {
-        "biome": "hills"
+        "tile": "hills"
       },
       {
-        "biome": "hills"
+        "tile": "hills"
       },
       {
-        "biome": "mountains"
+        "tile": "mountains"
       },
       {
-        "biome": "mountains"
+        "tile": "mountains"
       },
       {
-        "biome": "hills"
+        "tile": "hills"
       },
       {
-        "biome": "hills"
+        "tile": "hills"
       },
       {
         "site": {
           "type": "village",
           "name": "Test Village",
           "flavor": "A quiet village rests here. You could ENTER."
-        }
+        },
+        "tile": "village"
       },
       {
-        "biome": "plains"
+        "tile": "plains"
       },
       {
-        "biome": "plains"
+        "tile": "plains"
       },
       {
-        "biome": "plains"
+        "tile": "plains"
       }
     ]
   ],
@@ -857,296 +861,6 @@
       "y": 9,
       "flavor": "Ships sway at the port. ENTER to visit the docks."
     }
-  ],
-  "grid": [
-    [
-      "plains",
-      "plains",
-      "plains",
-      "coast",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean"
-    ],
-    [
-      "forest",
-      "plains",
-      "coast",
-      "coast",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean"
-    ],
-    [
-      "plains",
-      "coast",
-      "coast",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean"
-    ],
-    [
-      "coast",
-      "coast",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean"
-    ],
-    [
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean"
-    ],
-    [
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean"
-    ],
-    [
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean"
-    ],
-    [
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean"
-    ],
-    [
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "coast",
-      "coast",
-      "coast",
-      "coast",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean",
-      "ocean"
-    ],
-    [
-      "ocean",
-      "ocean",
-      "ocean",
-      "coast",
-      "coast",
-      "coast",
-      "forest",
-      "forest",
-      "coast",
-      "coast",
-      "ocean",
-      "ocean",
-      "ocean",
-      "coast",
-      "port",
-      "coast"
-    ],
-    [
-      "coast",
-      "ocean",
-      "ocean",
-      "coast",
-      "plains",
-      "marsh-lite",
-      "plains",
-      "plains",
-      "coast",
-      "ocean",
-      "coast",
-      "coast",
-      "coast",
-      "coast",
-      "plains",
-      "city"
-    ],
-    [
-      "coast",
-      "coast",
-      "coast",
-      "coast",
-      "plains",
-      "plains",
-      "plains",
-      "forest",
-      "coast",
-      "coast",
-      "coast",
-      "town",
-      "plains",
-      "marsh-lite",
-      "forest",
-      "forest"
-    ],
-    [
-      "coast",
-      "coast",
-      "coast",
-      "coast",
-      "plains",
-      "plains",
-      "hills",
-      "plains",
-      "plains",
-      "forest",
-      "forest",
-      "plains",
-      "plains",
-      "plains",
-      "forest",
-      "plains"
-    ],
-    [
-      "coast",
-      "ocean",
-      "ocean",
-      "coast",
-      "plains",
-      "plains",
-      "hills",
-      "hills",
-      "hills",
-      "hills",
-      "hills",
-      "hills",
-      "plains",
-      "forest",
-      "plains",
-      "plains"
-    ],
-    [
-      "ocean",
-      "ocean",
-      "ocean",
-      "coast",
-      "plains",
-      "plains",
-      "hills",
-      "hills",
-      "hills",
-      "mountains",
-      "hills",
-      "hills",
-      "plains",
-      "plains",
-      "plains",
-      "forest"
-    ],
-    [
-      "ocean",
-      "ocean",
-      "ocean",
-      "coast",
-      "plains",
-      "plains",
-      "hills",
-      "hills",
-      "mountains",
-      "mountains",
-      "hills",
-      "hills",
-      "village",
-      "plains",
-      "plains",
-      "plains"
-    ]
   ],
   "sites": [
     {


### PR DESCRIPTION
## Summary
- Support tile-based shards by replacing grid with a canonical tile array
- Update loaders, overlays, and movement rules to read from the new `tiles` field
- Adjust world loader and persistence to emit and ingest tile keys

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afc6527a94832db28b87f6ff1fe112