### PR TITLE
Persist character current location

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -49,6 +49,12 @@ def create_app():
                         conn.execute(sa.text("UPDATE character SET is_active = 0 WHERE is_deleted = 1"))
                 if "last_seen_at" not in cols:
                     conn.execute(sa.text("ALTER TABLE character ADD COLUMN last_seen_at DATETIME"))
+                if "cur_loc" not in cols:
+                    conn.execute(sa.text("ALTER TABLE character ADD COLUMN cur_loc VARCHAR(64)"))
+                    if "x" in cols and "y" in cols:
+                        conn.execute(sa.text(
+                            "UPDATE character SET cur_loc = x || ',' || y WHERE x IS NOT NULL AND y IS NOT NULL"
+                        ))
 
     # Blueprints
     app.register_blueprint(auth_bp, url_prefix="/api/auth")

--- a/app/models/characters.py
+++ b/app/models/characters.py
@@ -28,6 +28,7 @@ class Character(Model):
     shard_id = db.Column(db.String(64))
     x = db.Column(db.Integer)
     y = db.Column(db.Integer)
+    cur_loc = db.Column(db.String(64))
 
     # easy-mode state bucket (inventory, quests, flags) -> normalize later
     state = db.Column(db.JSON)

--- a/app/models/items.py
+++ b/app/models/items.py
@@ -1,8 +1,13 @@
 from .base import db, Model
 from sqlalchemy.dialects.postgresql import JSONB
 
+
 def _JSON():
-    return JSONB if db.engine.url.get_backend_name() == "postgresql" else db.JSON
+    try:
+        return JSONB if db.engine.url.get_backend_name() == "postgresql" else db.JSON
+    except Exception:
+        # Fallback when called outside application context
+        return db.JSON
 
 class Item(Model):
     __tablename__ = "items"

--- a/app/player_service.py
+++ b/app/player_service.py
@@ -7,9 +7,12 @@ subsequent requests.  This replaces the old module-level singleton pattern.
 """
 
 from typing import Dict
-from flask import session
+from flask import session, current_app
+from flask_login import current_user
+import datetime as dt
 
 from server.player_engine import Player, QuestState
+from .models import db, User, Character
 
 
 def _deserialize(data: Dict) -> Player:
@@ -36,5 +39,29 @@ def get_player() -> Player:
 
 
 def save_player(player: Player) -> None:
-    """Persist the player's state back to the session."""
+    """Persist the player's state back to the session and database."""
     session["player"] = player.as_public()
+
+    # Only attempt DB persistence if Flask-Login is set up
+    if not hasattr(current_app, "login_manager"):
+        return
+
+    if current_user.is_authenticated:
+        user = User.query.get(current_user.user_id)
+        if user and user.selected_character_id:
+            ch = (
+                Character.query
+                .filter_by(
+                    character_id=user.selected_character_id,
+                    user_id=user.user_id,
+                    is_active=True,
+                )
+                .first()
+            )
+            if ch:
+                x, y = player.pos
+                ch.x = int(x)
+                ch.y = int(y)
+                ch.cur_loc = f"{int(x)},{int(y)}"
+                ch.last_seen_at = dt.datetime.utcnow()
+                db.session.commit()

--- a/migrations/versions/1d4be5908e27_add_cur_loc_to_character.py
+++ b/migrations/versions/1d4be5908e27_add_cur_loc_to_character.py
@@ -1,0 +1,24 @@
+"""add cur_loc to character
+
+Revision ID: 1d4be5908e27
+Revises: 4d862eaccc3f
+Create Date: 2025-09-01 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '1d4be5908e27'
+down_revision = '4d862eaccc3f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('character', sa.Column('cur_loc', sa.String(length=64), nullable=True))
+    op.execute("UPDATE character SET cur_loc = x || ',' || y WHERE x IS NOT NULL AND y IS NOT NULL")
+
+
+def downgrade():
+    op.drop_column('character', 'cur_loc')

--- a/tests/test_character_location_persistence.py
+++ b/tests/test_character_location_persistence.py
@@ -1,0 +1,34 @@
+from app import create_app
+from server.config import START_POS
+import uuid
+
+
+def test_cur_loc_updates_and_persists():
+    app = create_app()
+    with app.test_client() as client, app.app_context():
+        from app.models import Character
+        # register and login
+        email = f"{uuid.uuid4().hex}@t.com"
+        handle = uuid.uuid4().hex[:8]
+        reg = client.post(
+            '/api/auth/register',
+            json={'email': email, 'display_name': 'P', 'handle': handle, 'age': 20}
+        )
+        assert reg.status_code == 200
+        # create and select character
+        created = client.post('/api/characters', json={'name': 'Hero', 'class_id': 'warrior'})
+        cid = created.get_json()['character_id']
+        client.post('/api/characters/select', json={'character_id': cid})
+        # spawn and move
+        client.post('/api/spawn', json={})
+        client.post('/api/move', json={'dx': 1, 'dy': 0})
+        ch = Character.query.get(cid)
+        assert ch.x == START_POS[0] + 1
+        assert ch.y == START_POS[1]
+        assert ch.cur_loc == f"{ch.x},{ch.y}"
+        # clear session and spawn again; position should persist
+        with client.session_transaction() as sess:
+            sess.clear()
+        resp = client.post('/api/spawn', json={})
+        data = resp.get_json()
+        assert data['player']['pos'] == [START_POS[0] + 1, START_POS[1]]


### PR DESCRIPTION
## Summary
- add `cur_loc` column to `character` table and model
- persist player coordinates and `cur_loc` on each move
- include migration and regression test for location persistence

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1b34ed028832d867ee95a482a2813