### PR TITLE
Use Session.get for primary key lookups

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -12,8 +12,7 @@ from server.combat import maybe_spawn, resolve_combat
 from server.config import START_POS
 
 from flask_login import current_user
-from app.models.users import User
-from app.models.characters import Character
+from app.models import db, User, Character
 from app.player_service import get_player, save_player
 
 bp = Blueprint("core_api", __name__, url_prefix="/api")
@@ -59,7 +58,7 @@ def api_spawn():
 
     # pull last known position from DB if available
     if current_user.is_authenticated:
-        user = User.query.get(current_user.user_id)
+        user = db.session.get(User, current_user.user_id)
         if user and user.selected_character_id:
             ch = Character.query.filter_by(
                 character_id=user.selected_character_id,

--- a/app/api_admin.py
+++ b/app/api_admin.py
@@ -79,7 +79,7 @@ def users_list():
 
 @admin_api.get("/users/<user_id>")
 def user_detail(user_id):
-    u = User.query.get(user_id)
+    u = db.session.get(User, user_id)
     if not u:
         return jsonify(error="User not found"), 404
     chars = (Character.query
@@ -130,7 +130,7 @@ def characters_list():
 
 @admin_api.get("/characters/<character_id>")
 def character_detail(character_id):
-    c = Character.query.get(character_id)
+    c = db.session.get(Character, character_id)
     if not c:
         return jsonify(error="Character not found"), 404
 
@@ -188,7 +188,7 @@ def instances_list():
 @admin_api.get("/characters/<character_id>/inventory")
 def inventory_list(character_id):
     page, limit, offset = _pg()
-    c = Character.query.get(character_id)
+    c = db.session.get(Character, character_id)
     if not c: return jsonify(error="Character not found"), 404
     q = (db.session.query(
             CharacterInventory.slot_index, CharacterInventory.item_id, Item.name,

--- a/app/api_items.py
+++ b/app/api_items.py
@@ -18,7 +18,7 @@ def create_item():
     if missing:
         return jsonify(error=f"Missing fields: {', '.join(missing)}"), 400
 
-    item = Item.query.get(data['item_id'])
+    item = db.session.get(Item, data['item_id'])
     if not item:
         item = Item(
             item_id=data['item_id'],
@@ -56,7 +56,7 @@ def create_item_instance():
     if missing:
         return jsonify(error=f"Missing fields: {', '.join(missing)}"), 400
 
-    item = Item.query.get(data['item_id'])
+    item = db.session.get(Item, data['item_id'])
     if not item:
         return jsonify(error="Item not found"), 404
 
@@ -79,7 +79,7 @@ def grant_inventory(character_id):
     if missing:
         return jsonify(error=f"Missing fields: {', '.join(missing)}"), 400
 
-    char = Character.query.get(character_id)
+    char = db.session.get(Character, character_id)
     if not char:
         return jsonify(error='Character not found'), 404
 

--- a/app/auth.py
+++ b/app/auth.py
@@ -11,7 +11,7 @@ HANDLE_RE = re.compile(r"^[a-z0-9_]{3,32}$", re.I)
 
 @login_manager.user_loader
 def load_user(user_id):  # called by Flask-Login using session cookie
-    return User.query.get(user_id)
+    return db.session.get(User, user_id)
 
 @auth_bp.route("/register", methods=["POST"])
 def register():

--- a/app/characters.py
+++ b/app/characters.py
@@ -174,7 +174,7 @@ def select_character():
     ch = Character.query.filter_by(character_id=character_id, user_id=current_user.user_id, is_active=True).first()
     if not ch:
         return jsonify(error="not found"), 404
-    user = User.query.get(current_user.user_id)
+    user = db.session.get(User, current_user.user_id)
     user.selected_character_id = ch.character_id
     ch.last_seen_at = _now()
     db.session.commit()
@@ -184,7 +184,7 @@ def select_character():
 @characters_bp.route("/api/characters/active", methods=["GET"])
 @login_required
 def active_character():
-    user = User.query.get(current_user.user_id)
+    user = db.session.get(User, current_user.user_id)
     if not user or not user.selected_character_id:
         return jsonify(error="no active character"), 404
     ch = (Character.query
@@ -209,7 +209,7 @@ def active_character():
 @login_required
 def autosave_state():
     data = request.get_json(force=True) or {}
-    user = User.query.get(current_user.user_id)
+    user = db.session.get(User, current_user.user_id)
     if not user or not user.selected_character_id:
         return jsonify(error="no character selected"), 400
     ch = Character.query.filter_by(character_id=user.selected_character_id, user_id=user.user_id, is_active=True).first()

--- a/app/player_service.py
+++ b/app/player_service.py
@@ -47,7 +47,7 @@ def save_player(player: Player) -> None:
         return
 
     if current_user.is_authenticated:
-        user = User.query.get(current_user.user_id)
+        user = db.session.get(User, current_user.user_id)
         if user and user.selected_character_id:
             ch = (
                 Character.query

--- a/tests/test_character_location_persistence.py
+++ b/tests/test_character_location_persistence.py
@@ -6,7 +6,7 @@ import uuid
 def test_cur_loc_updates_and_persists():
     app = create_app()
     with app.test_client() as client, app.app_context():
-        from app.models import Character
+        from app.models import db, Character
         # register and login
         email = f"{uuid.uuid4().hex}@t.com"
         handle = uuid.uuid4().hex[:8]
@@ -22,7 +22,7 @@ def test_cur_loc_updates_and_persists():
         # spawn and move
         client.post('/api/spawn', json={})
         client.post('/api/move', json={'dx': 1, 'dy': 0})
-        ch = Character.query.get(cid)
+        ch = db.session.get(Character, cid)
         assert ch.x == START_POS[0] + 1
         assert ch.y == START_POS[1]
         assert ch.cur_loc == f"{ch.x},{ch.y}"


### PR DESCRIPTION
## Summary
- Replace legacy `Query.get` usages with `db.session.get` for primary key lookups throughout the app and CLI
- Adjust test to use `db.session.get`

## Testing
- `python db_cli.py seed-world --count 1 --prefix ci_demo --overwrite --assign-email none@example.com`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b25335b0d8832db99a981e41176767