### PR TITLE
Ensure town demo renders 3x3 grid

### DIFF
--- a/templates/mvp3.html
+++ b/templates/mvp3.html
@@ -7,6 +7,7 @@
 
   <link rel="stylesheet" href="{{ url_for('static', filename='css/mvp3.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/mapOverlay.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/town.css') }}">
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@600..900&family=IM+Fell+English:ital@0;1&family=Crimson+Text:wght@400;600&display=swap" rel="stylesheet">
 
   <script>window.SHARDBIOME_SOURCE = 'grid';</script>


### PR DESCRIPTION
## Summary
- Dispatch `game:poi` events when interacting and switch movement API when in a town
- Listen for town interactions to load rooms and render 3x3 grid
- Load dedicated town styles so grid displays correctly

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_68b660d0e454832d82f606f504abcd0f