### PR TITLE
Restore server package initialization and pytest path

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,0 +1,7 @@
+"""Server package initialization."""
+
+# Expose primary APIs for convenience
+from .world_loader import load_world, get_room, add_safe_zone
+from .player_engine import move, ensure_first_quest, check_quests
+from .combat import maybe_spawn, resolve_combat
+from .config import START_POS, START_TOWN_COORDS, PORT_TOWN_COORDS, AMBUSH_COORDS, TOWN_GRID_SIZE


### PR DESCRIPTION
## Summary
- add server package `__init__` exposing key modules
- configure pytest to include project root in Python path

## Testing
- `pytest -q`
- `python db_cli.py seed-starter`
- `python - <<'PY'\nfrom app import create_app\napp=create_app(); c=app.test_client();\nprint('spawn', c.post('/api/game/characters', json={'name':'Temp','class_id':'warrior'}).get_json())\nPY`

------
https://chatgpt.com/codex/tasks/task_e_68b6e00c1534832db0553a99662a3195