### PR TITLE
Avoid overwriting character location before spawn

### DIFF
--- a/app/player_service.py
+++ b/app/player_service.py
@@ -59,9 +59,10 @@ def save_player(player: Player) -> None:
                 .first()
             )
             if ch:
-                x, y = player.pos
-                ch.x = int(x)
-                ch.y = int(y)
-                ch.cur_loc = f"{int(x)},{int(y)}"
+                new_x, new_y = map(int, player.pos)
+                if (new_x, new_y) != (ch.x, ch.y):
+                    if (new_x, new_y) != (0, 0) or ch.x is None or ch.y is None:
+                        ch.x, ch.y = new_x, new_y
+                        ch.cur_loc = f"{new_x},{new_y}"
                 ch.last_seen_at = dt.datetime.utcnow()
                 db.session.commit()


### PR DESCRIPTION
## Summary
- Update `save_player` to only persist position when the player has spawned or the database lacks coordinates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b71877ded4832db11a1cd3c7a6b0a9