### PR TITLE
feat(api): unify character endpoints under /api/game/characters; deprecate /api/characters; normalize spawn + JSON errors

### DIFF
--- a/app/api_items.py
+++ b/app/api_items.py
@@ -71,7 +71,7 @@ def create_item_instance():
     return jsonify(message='instance created', instance_id=inst.instance_id), 201
 
 
-@api.route('/characters/<character_id>/inventory', methods=['POST'])
+@api.route('/game/characters/<character_id>/inventory', methods=['POST'])
 def grant_inventory(character_id):
     data = request.get_json(force=True, silent=True) or {}
     required = ['slot_index', 'item_id', 'instance_id', 'qty', 'equipped']

--- a/app/characters.py
+++ b/app/characters.py
@@ -1,10 +1,9 @@
 # app/characters.py
-import json, datetime as dt
+import json
 from pathlib import Path
-from flask import Blueprint, jsonify, request, render_template
-from flask_login import login_required, current_user
-from .models import db, User, Character
-from server.config import START_POS
+from flask import Blueprint, jsonify, render_template, redirect
+from flask_login import login_required
+from .models import db
 
 characters_bp = Blueprint("characters_bp", __name__)
 
@@ -35,23 +34,6 @@ def _load_published_classes():
             continue
     return out
 
-def _class_by_id(cid: str):
-    for c in _load_published_classes():
-        if c["class_id"] == cid:
-            return c
-    return None
-
-def _now():
-    return dt.datetime.utcnow()
-
-def _deep_merge(a, b):
-    """Merge dict b into dict a (in place). Lists are replaced."""
-    for k, v in (b or {}).items():
-        if isinstance(v, dict) and isinstance(a.get(k), dict):
-            _deep_merge(a[k], v)
-        else:
-            a[k] = v
-    return a
 
 # ----- views (pages) -----
 @characters_bp.route("/characters")
@@ -74,172 +56,31 @@ def list_published_classes():
 @characters_bp.route("/api/characters", methods=["GET"])
 @login_required
 def list_characters():
-    chars = (Character.query
-             .filter_by(user_id=current_user.user_id, is_active=True)
-             .order_by(Character.created_at.asc())
-             .all())
-    def to_json(c: Character):
-        return {
-            "character_id": c.character_id,
-            "name": c.name,
-            "class_id": c.class_id,
-            "level": c.level,
-            "bio": c.biography,
-            "created_at": c.created_at.isoformat() + "Z",
-            "updated_at": c.updated_at.isoformat() + "Z",
-            "last_seen_at": (c.last_seen_at.isoformat() + "Z") if c.last_seen_at else None,
-        }
-    return jsonify([to_json(c) for c in chars]), 200
+    return redirect("/api/game/characters", code=308)
 
 @characters_bp.route("/api/characters", methods=["POST"])
 @login_required
 def create_character():
-    data = request.get_json(force=True) or {}
-    name     = (data.get("name") or "").strip()
-    class_id = (data.get("class_id") or "").strip()
-    sex      = (data.get("sex") or "").strip() or None
-    age      = int(data.get("age") or 0) or None
-    bio      = (data.get("bio") or "").strip() or None
-
-    if not name or not class_id:
-        return jsonify(error="name and class_id required"), 400
-    exists = Character.query.filter_by(user_id=current_user.user_id, name=name, is_active=True).first()
-    if exists:
-        return jsonify(error="character name already used"), 409
-
-    cdef = _class_by_id(class_id)
-    if not cdef:
-        return jsonify(error="invalid class_id"), 404
-
-    initial_state = {
-        "class_id": class_id,
-        "race_id": data.get("race_id") or None,
-        "level": 1,
-        "xp": 0,
-        "attributes": dict(cdef.get("base_attributes", {})),
-        "skills": {k: v.get("start", 0) for k, v in (cdef.get("skills") or {}).items()},
-        "abilities": {a["ability_id"]: {"rank": 1, "cooldown": 0} for a in (cdef.get("abilities") or []) if a.get("unlock_level", 1) <= 1},
-        "equipment": {},
-        "inventory": [{"item_id": i, "qty": 1} for i in (cdef.get("starting_equipment") or [])],
-        "quests": {"active": [], "completed": []},
-        "flags": {},
-        "last_room_id": None,
-        "hunger": 0,
-        "thirst": 0,
-        "buffs": []
-    }
-
-    ch = Character(
-        user_id=current_user.user_id,
-        name=name,
-        class_id=class_id,
-        level=1,
-        sex=sex,
-        age=age,
-        biography=bio,
-        shard_id="00089451_test123",
-        x=START_POS[0],
-        y=START_POS[1],
-        state=initial_state,
-        is_active=True,
-        created_at=_now(),
-        updated_at=_now(),
-        last_seen_at=None,
-    )
-    db.session.add(ch)
-    db.session.commit()
-
-    return jsonify(character_id=ch.character_id), 201
+    return redirect("/api/game/characters", code=308)
 
 @characters_bp.route("/api/characters/<string:character_id>", methods=["DELETE"])
 @login_required
 def delete_character(character_id):
-    ch = Character.query.filter_by(character_id=character_id, user_id=current_user.user_id, is_active=True).first()
-    if not ch:
-        return jsonify(error="not found"), 404
-    ch.is_active = False
-    if current_user.selected_character_id == ch.character_id:
-        current_user.selected_character_id = None
-    ch.updated_at = _now()
-    db.session.commit()
-    return jsonify(ok=True), 200
+    return jsonify(error="deprecated; use /api/game/characters/<id>"), 410
 
 @characters_bp.route("/api/characters/select", methods=["POST"])
 @login_required
 def select_character():
-    data = request.get_json(force=True) or {}
-    character_id = data.get("character_id")
-    if not character_id:
-        return jsonify(error="character_id required"), 400
-    ch = Character.query.filter_by(character_id=character_id, user_id=current_user.user_id, is_active=True).first()
-    if not ch:
-        return jsonify(error="not found"), 404
-    user = db.session.get(User, current_user.user_id)
-    user.selected_character_id = ch.character_id
-    ch.last_seen_at = _now()
-    db.session.commit()
-    return jsonify(ok=True), 200
+    return jsonify(error="deprecated; use /api/game/characters/select"), 410
 
 
 @characters_bp.route("/api/characters/active", methods=["GET"])
 @login_required
 def active_character():
-    user = db.session.get(User, current_user.user_id)
-    if not user or not user.selected_character_id:
-        return jsonify(error="no active character"), 404
-    ch = (Character.query
-          .filter_by(character_id=user.selected_character_id, user_id=user.user_id, is_active=True)
-          .first())
-    if not ch:
-        return jsonify(error="character not found"), 404
-    return jsonify({
-        "character_id": ch.character_id,
-        "name": ch.name,
-        "class_id": ch.class_id,
-        "level": ch.level,
-        "bio": ch.biography,
-        "shard_id": ch.shard_id,
-        "x": ch.x,
-        "y": ch.y,
-        "last_seen_at": ch.last_seen_at.isoformat() + "Z" if ch.last_seen_at else None,
-    }), 200
+    return jsonify(error="deprecated; use /api/game/characters/active"), 410
 
 # ----- autosave (merge partial state) -----
 @characters_bp.route("/api/characters/autosave", methods=["POST"])
 @login_required
 def autosave_state():
-    data = request.get_json(force=True) or {}
-    user = db.session.get(User, current_user.user_id)
-    if not user or not user.selected_character_id:
-        return jsonify(error="no character selected"), 400
-    ch = Character.query.filter_by(character_id=user.selected_character_id, user_id=user.user_id, is_active=True).first()
-    if not ch:
-        return jsonify(error="character not found"), 404
-
-    # update position if provided
-    shard_id = data.pop("shard_id", None)
-    if shard_id is not None:
-        ch.shard_id = shard_id
-    x = data.pop("x", None)
-    if x is not None:
-        ch.x = x
-    y = data.pop("y", None)
-    if y is not None:
-        ch.y = y
-
-    # Merge supplied state
-    state_patch = data.pop("state", {})
-    current = dict(ch.state or {})
-    _deep_merge(current, state_patch)
-    ch.state = current
-
-    # optional: level in both column + state
-    if "level" in data:
-        try:
-            ch.level = int(data["level"])
-        except Exception:
-            pass
-    ch.updated_at = _now()
-    ch.last_seen_at = _now()
-    db.session.commit()
-    return jsonify(ok=True, updated_at=ch.updated_at.isoformat() + "Z"), 200
+    return jsonify(error="deprecated; use /api/game/characters/autosave"), 410

--- a/server/config.py
+++ b/server/config.py
@@ -1,6 +1,9 @@
-START_POS = (12, 15)
+"""Shared gameplay coordinate constants."""
+
 # Demo gameplay coordinates
 START_TOWN_COORDS = (12, 15)
+# Legacy alias used by parts of the codebase; keep in sync with START_TOWN_COORDS
+START_POS = START_TOWN_COORDS
 PORT_TOWN_COORDS = (14, 9)
 AMBUSH_COORDS = (13, 12)
 TOWN_GRID_SIZE = (3, 3)

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -84,7 +84,7 @@ export const API = {
 
   // ----- character API -----
   async charactersList() {
-    const r = await fetch('/api/characters', { credentials: 'include' });
+    const r = await fetch('/api/game/characters', { credentials: 'include' });
     if (!r.ok) throw new Error('Failed to list characters');
     return r.json();
   },
@@ -102,7 +102,7 @@ export const API = {
   },
 
   async characterSelect(character_id) {
-    const r = await fetch('/api/characters/select', {
+    const r = await fetch('/api/game/characters/select', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
@@ -114,14 +114,14 @@ export const API = {
   },
 
   async characterActive() {
-    const r = await fetch('/api/characters/active', { credentials: 'include' });
+    const r = await fetch('/api/game/characters/active', { credentials: 'include' });
     if (r.status === 404) return null;
     if (!r.ok) throw new Error('Failed to get active character');
     return r.json();
   },
 
   async autosaveCharacter(payload) {
-    const r = await fetch('/api/characters/autosave', {
+    const r = await fetch('/api/game/characters/autosave', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',

--- a/templates/character_create.html
+++ b/templates/character_create.html
@@ -135,7 +135,7 @@
             bio: $('bio').value
           };
           if(!payload.name){ alert('Name required'); return; }
-          await api('/api/characters',{method:'POST',headers:{'Content-Type':'application/json'},body: JSON.stringify(payload)});
+          await api('/api/game/characters',{method:'POST',headers:{'Content-Type':'application/json'},body: JSON.stringify(payload)});
           // send them to select page so they can pick and play
           window.location.href = '/characters';
         }catch(e){ alert(e.message || 'Create failed'); }

--- a/templates/characters.html
+++ b/templates/characters.html
@@ -44,7 +44,7 @@
         </div>`;
     }
     async function load(){
-      const list = await api('/api/characters');
+      const list = await api('/api/game/characters');
       const el = document.getElementById('grid');
       el.innerHTML = list.map(card).join('') || '<div class="dim">No characters yet. Create one!</div>';
       el.querySelectorAll('button').forEach(b=>{
@@ -53,11 +53,11 @@
           const act = b.getAttribute('data-act');
           try{
             if(act==='play'){
-              await api('/api/characters/select',{method:'POST',headers:{'Content-Type':'application/json'}, body: JSON.stringify({character_id:id})});
+              await api('/api/game/characters/select',{method:'POST',headers:{'Content-Type':'application/json'}, body: JSON.stringify({character_id:id})});
               window.location.href = '/mvp';
             }else if(act==='delete'){
               if(confirm('Delete this character?')){
-                await api(`/api/characters/${id}`,{method:'DELETE'});
+                await api(`/api/game/characters/${id}`,{method:'DELETE'});
                 await load();
               }
             }

--- a/templates/item_forge.html
+++ b/templates/item_forge.html
@@ -205,7 +205,7 @@
         <div style="font-size:11px; color:var(--muted)">Temper steel, bind runes, mint instances</div>
       </div>
     </div>
-    <span class="tag">/api/items • /api/item_instances • /api/characters/&lt;id&gt;/inventory</span>
+    <span class="tag">/api/items • /api/item_instances • /api/game/characters/&lt;id&gt;/inventory</span>
   </header>
 
   <main>
@@ -383,7 +383,7 @@
       mintInstance: (payload) =>
         fetch('/api/item_instances', { method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(payload) }),
       grantInventory: (character_id, payload) =>
-        fetch('/api/characters/'+encodeURIComponent(character_id)+'/inventory', { method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(payload) }),
+        fetch('/api/game/characters/'+encodeURIComponent(character_id)+'/inventory', { method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(payload) }),
     };
 
     /* ---------- DOM ---------- */
@@ -563,7 +563,7 @@
 
         const c1 = `curl -s -X POST http://localhost:5000/api/items -H "Content-Type: application/json" -d '${JSON.stringify(payload)}'`;
         const c2 = `curl -s -X POST http://localhost:5000/api/item_instances -H "Content-Type: application/json" -d '${JSON.stringify({item_id:payload.item_id,item_version:payload.item_version,quantity:qty})}'`;
-        const c3 = `curl -s -X POST http://localhost:5000/api/characters/${cid}/inventory -H "Content-Type: application/json" -d '${JSON.stringify({slot_index:slot,item_id:payload.item_id,instance_id:"$INSTANCE_ID",qty:qty,equipped:eq})}'`;
+        const c3 = `curl -s -X POST http://localhost:5000/api/game/characters/${cid}/inventory -H "Content-Type: application/json" -d '${JSON.stringify({slot_index:slot,item_id:payload.item_id,instance_id:"$INSTANCE_ID",qty:qty,equipped:eq})}'`;
         return [c1, c2, c3].join('\n# INSTANCE_ID is value from previous response\n');
       }catch(e){ return '# invalid JSON/payload – cannot build cURL' }
     }

--- a/tests/test_character_location_persistence.py
+++ b/tests/test_character_location_persistence.py
@@ -1,5 +1,5 @@
 from app import create_app
-from server.config import START_POS
+from server.config import START_TOWN_COORDS
 import uuid
 
 
@@ -16,19 +16,19 @@ def test_cur_loc_updates_and_persists():
         )
         assert reg.status_code == 200
         # create and select character
-        created = client.post('/api/characters', json={'name': 'Hero', 'class_id': 'warrior'})
+        created = client.post('/api/game/characters', json={'name': 'Hero', 'class_id': 'warrior'})
         cid = created.get_json()['character_id']
-        client.post('/api/characters/select', json={'character_id': cid})
+        client.post('/api/game/characters/select', json={'character_id': cid})
         # spawn and move
         client.post('/api/spawn', json={})
         client.post('/api/move', json={'dx': 1, 'dy': 0})
         ch = db.session.get(Character, cid)
-        assert ch.x == START_POS[0] + 1
-        assert ch.y == START_POS[1]
+        assert ch.x == START_TOWN_COORDS[0] + 1
+        assert ch.y == START_TOWN_COORDS[1]
         assert ch.cur_loc == f"{ch.x},{ch.y}"
         # clear session and spawn again; position should persist
         with client.session_transaction() as sess:
             sess.clear()
         resp = client.post('/api/spawn', json={})
         data = resp.get_json()
-        assert data['player']['pos'] == [START_POS[0] + 1, START_POS[1]]
+        assert data['player']['pos'] == [START_TOWN_COORDS[0] + 1, START_TOWN_COORDS[1]]


### PR DESCRIPTION
## Summary
- centralize character create/list/delete/select/active/autosave under `/api/game/characters`
- deprecate old `/api/characters` routes with redirects or 410 JSON errors
- initialize `cur_loc` and unify spawn constants at `START_TOWN_COORDS`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b71cf58588832dbbe91f95d7c8720f