### PR TITLE
Remove character xy columns

### DIFF
--- a/app/admin_console.py
+++ b/app/admin_console.py
@@ -53,10 +53,6 @@ def cmd_char_move(argv: list[str]):
         coords = {"x": ns.x, "y": ns.y}
 
     ch.last_coords = coords
-    if hasattr(ch, "x"):
-        ch.x = coords["x"]
-    if hasattr(ch, "y"):
-        ch.y = coords["y"]
     ch.cur_loc = f"{coords['x']},{coords['y']}"
     db.session.commit()
 

--- a/app/api_admin.py
+++ b/app/api_admin.py
@@ -426,10 +426,6 @@ def admin_char_teleport(character_id):
     except Exception:
         return jsonify(error="x,y required (ints)"), 400
     ch.last_coords = coords
-    if hasattr(ch, "x"):
-        ch.x = coords["x"]
-    if hasattr(ch, "y"):
-        ch.y = coords["y"]
     ch.cur_loc = f"{coords['x']},{coords['y']}"
     db.session.commit()
     audit("char.teleport", "character", character_id, payload={"coords": coords, "note": body.get("note")})
@@ -437,8 +433,8 @@ def admin_char_teleport(character_id):
         "character_id": ch.character_id,
         "first_time_spawn": ch.first_time_spawn,
         "last_coords": ch.last_coords,
-        "x": getattr(ch, "x", None),
-        "y": getattr(ch, "y", None),
+        "x": (ch.last_coords or {}).get("x"),
+        "y": (ch.last_coords or {}).get("y"),
         "cur_loc": ch.cur_loc,
     }
     return jsonify(payload)

--- a/app/api_gameplay.py
+++ b/app/api_gameplay.py
@@ -75,8 +75,6 @@ def _get_coords(ch: Character) -> tuple[int, int]:
 def _set_coords(ch: Character, x: int, y: int) -> None:
     ch.last_coords = {"x": int(x), "y": int(y)}
     ch.cur_loc = f"{int(x)},{int(y)}"
-    ch.x = int(x)
-    ch.y = int(y)
 
 
 @bp.get("/characters")
@@ -119,8 +117,6 @@ def create_character():
         first_time_spawn=spawn,
         last_coords=spawn.copy(),
         cur_loc=f"{START_TOWN_COORDS[0]},{START_TOWN_COORDS[1]}",
-        x=spawn["x"],
-        y=spawn["y"],
         state={},
     )
     db.session.add(ch)

--- a/app/models/characters.py
+++ b/app/models/characters.py
@@ -29,8 +29,6 @@ class Character(Model):
     first_time_spawn = db.Column(db.JSON)
     last_coords = db.Column(db.JSON)
     cur_loc = db.Column(db.String(64))
-    x = db.Column(db.Integer)
-    y = db.Column(db.Integer)
 
     # easy-mode state bucket (inventory, quests, flags) -> normalize later
     state = db.Column(db.JSON)

--- a/db_cli.py
+++ b/db_cli.py
@@ -139,8 +139,22 @@ def cmd_characters(args):
         q = q.filter(Character.user_id == u.user_id)
     if args.name: q = q.filter(Character.name.ilike(f"%{args.name}%"))
     q = q.order_by(Character.created_at.asc())
-    rows = [(c.character_id, c.name, c.class_id or "-", c.level or 1, c.user_id,
-             c.shard_id or "-", c.x, c.y, _fmt_dt(c.created_at)) for c in q.all()]
+    rows = []
+    for c in q.all():
+        coords = c.last_coords or c.first_time_spawn or {}
+        rows.append(
+            (
+                c.character_id,
+                c.name,
+                c.class_id or "-",
+                c.level or 1,
+                c.user_id,
+                c.shard_id or "-",
+                coords.get("x"),
+                coords.get("y"),
+                _fmt_dt(c.created_at),
+            )
+        )
     print_rows(rows, ["character_id","name","class","level","user_id","shard_id","x","y","created_at"])
 
 def cmd_tables(_args):

--- a/migrations/versions/85b58d9a7ae2_add_character_xy.py
+++ b/migrations/versions/85b58d9a7ae2_add_character_xy.py
@@ -1,0 +1,82 @@
+"""add x and y columns to character table
+
+Revision ID: 85b58d9a7ae2
+Revises: 276eb85f3f4d
+Create Date: 2025-09-02 21:00:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "85b58d9a7ae2"
+down_revision = "276eb85f3f4d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("character", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("x", sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column("y", sa.Integer(), nullable=True))
+
+    conn = op.get_bind()
+    dialect = conn.dialect.name
+
+    if dialect == "sqlite":
+        conn.execute(sa.text(
+            """
+            UPDATE character
+            SET x = json_extract(last_coords, '$.x'),
+                y = json_extract(last_coords, '$.y')
+            WHERE last_coords IS NOT NULL
+        """
+        ))
+        conn.execute(sa.text(
+            """
+            UPDATE character
+            SET x = COALESCE(x, json_extract(first_time_spawn, '$.x')),
+                y = COALESCE(y, json_extract(first_time_spawn, '$.y'))
+            WHERE first_time_spawn IS NOT NULL
+        """
+        ))
+        conn.execute(sa.text(
+            """
+            UPDATE character
+            SET x = COALESCE(x, CAST(substr(cur_loc, 1, instr(cur_loc, ',')-1) AS INT)),
+                y = COALESCE(y, CAST(substr(cur_loc, instr(cur_loc, ',')+1) AS INT))
+            WHERE cur_loc IS NOT NULL
+        """
+        ))
+    else:
+        conn.execute(sa.text(
+            """
+            UPDATE character
+            SET x = CAST(last_coords->>'x' AS INTEGER),
+                y = CAST(last_coords->>'y' AS INTEGER)
+            WHERE last_coords IS NOT NULL
+        """
+        ))
+        conn.execute(sa.text(
+            """
+            UPDATE character
+            SET x = COALESCE(x, CAST(first_time_spawn->>'x' AS INTEGER)),
+                y = COALESCE(y, CAST(first_time_spawn->>'y' AS INTEGER))
+            WHERE first_time_spawn IS NOT NULL
+        """
+        ))
+        conn.execute(sa.text(
+            """
+            UPDATE character
+            SET x = COALESCE(x, CAST(split_part(cur_loc, ',', 1) AS INTEGER)),
+                y = COALESCE(y, CAST(split_part(cur_loc, ',', 2) AS INTEGER))
+            WHERE cur_loc IS NOT NULL
+        """
+        ))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("character", schema=None) as batch_op:
+        batch_op.drop_column("y")
+        batch_op.drop_column("x")

--- a/migrations/versions/9b07fd5d213a_drop_character_xy.py
+++ b/migrations/versions/9b07fd5d213a_drop_character_xy.py
@@ -1,0 +1,71 @@
+"""drop x and y columns from character table
+
+Revision ID: 9b07fd5d213a
+Revises: 85b58d9a7ae2
+Create Date: 2025-09-02 22:00:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "9b07fd5d213a"
+down_revision = "85b58d9a7ae2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    dialect = conn.dialect.name
+
+    if dialect == "sqlite":
+        conn.execute(sa.text(
+            """
+            UPDATE character
+            SET last_coords = json_set(COALESCE(last_coords, '{}'), '$.x', x, '$.y', y)
+            WHERE x IS NOT NULL AND y IS NOT NULL
+            """
+        ))
+    else:
+        conn.execute(sa.text(
+            """
+            UPDATE character
+            SET last_coords = jsonb_set(
+                jsonb_set(COALESCE(last_coords, '{}'::jsonb), '{x}', to_jsonb(x)),
+                '{y}', to_jsonb(y)
+            )
+            WHERE x IS NOT NULL AND y IS NOT NULL
+            """
+        ))
+
+    with op.batch_alter_table("character", schema=None) as batch_op:
+        batch_op.drop_column("x")
+        batch_op.drop_column("y")
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("character", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("y", sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column("x", sa.Integer(), nullable=True))
+
+    conn = op.get_bind()
+    dialect = conn.dialect.name
+
+    if dialect == "sqlite":
+        conn.execute(sa.text(
+            """
+            UPDATE character
+            SET x = json_extract(last_coords, '$.x'),
+                y = json_extract(last_coords, '$.y')
+            WHERE last_coords IS NOT NULL
+            """
+        ))
+    else:
+        conn.execute(sa.text(
+            """
+            UPDATE character
+            SET x = CAST(last_coords->>'x' AS INTEGER),
+                y = CAST(last_coords->>'y' AS INTEGER)
+            WHERE last_coords IS NOT NULL
+            """
+        ))

--- a/tests/test_autosave_spawn.py
+++ b/tests/test_autosave_spawn.py
@@ -19,8 +19,10 @@ def test_autosave_before_spawn_does_not_override_start():
         client.post('/api/characters/autosave', json={'x': 2, 'y': 0})
         ch = Character.query.get(cid)
         # position should remain at the intended start coords
-        assert (ch.x, ch.y) == START_POS
+        coords = ch.last_coords or {}
+        assert (coords.get("x"), coords.get("y")) == START_POS
         # spawning should still land at START_POS
         resp = client.post('/api/spawn', json={})
         data = resp.get_json()
         assert data['player']['pos'] == [START_POS[0], START_POS[1]]
+


### PR DESCRIPTION
## Summary
- drop direct `x`/`y` fields from `character` records and rely on `last_coords`/`first_time_spawn`
- adjust gameplay/admin logic and CLI to read/write positions from JSON coordinate data
- add migration that backfills `last_coords` from existing `x`/`y` then drops those columns

## Testing
- `AUTO_CREATE_TABLES=0 flask --app app:create_app db upgrade`
- `sqlite3 app.db 'PRAGMA table_info(character);'`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b760b94d60832d8a5a6d625913abba