### PR TITLE
docs: expand admin instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,100 @@
-# Demo Warrior Scenario
+# Shardbound Demo & Admin Tools
 
-## How to run the demo scenario
-1. `python tools/db_cli.py seed-starter`
+## Run the Server
+
+1. Install dependencies: `pip install -r requirements.txt`
+2. Seed demo data: `python db_cli.py seed-starter`
+3. Start the server: `python app.py`
+4. Visit `http://localhost:5000`
+
+To access admin features set an admin passphrase before running the server:
+```
+export ADMIN_PANEL_PASSWORD="your-passphrase"
+```
+
+## Admin Interfaces
+
+### UIs
+- **/admin/login** – enter the passphrase to access tools.
+- **/admin** – main panel with token generator and links to other tools.
+- **/vault** – browse users, characters, items, instances, inventory, recipes, resources and teleport characters.
+- **/itemForge** – item editor.
+- **/admin/console** – web console for running admin commands.
+
+### API Endpoints
+All endpoints require an admin token in `Authorization: Bearer <TOKEN>`.
+
+Users:
+- `GET /api/admin/users`
+- `GET /api/admin/users/<id>`
+- `POST /api/admin/users`
+- `PATCH /api/admin/users/<id>`
+- `DELETE /api/admin/users/<id>`
+
+Characters:
+- `GET /api/admin/characters`
+- `GET /api/admin/characters/<id>`
+- `POST /api/admin/characters`
+- `PATCH /api/admin/characters/<id>`
+- `DELETE /api/admin/characters/<id>`
+- `POST /api/admin/characters/<id>/teleport`
+- `GET /api/admin/characters/<id>/inventory`
+
+Items:
+- `GET /api/admin/items`
+- `GET /api/admin/items/<id>`
+- `POST /api/admin/items`
+- `PATCH /api/admin/items/<id>`
+- `DELETE /api/admin/items/<id>`
+- `GET /api/admin/item_instances`
+
+Optional Domains:
+- `GET /api/admin/recipes`
+- `GET /api/admin/resources`
+
+Admin Console:
+- `POST /api/admin/console/exec`
+
+Classes Admin:
+- `POST /api/classes-admin/init`
+- `GET /api/classes-admin/list`
+- `GET /api/classes-admin/get/<cid>`
+- `POST /api/classes-admin/new`
+- `PATCH/POST /api/classes-admin/save`
+- `POST /api/classes-admin/validate`
+- `POST /api/classes-admin/publish`
+- `POST /api/classes-admin/yank`
+
+### Admin Console Commands
+Accessible via the web console or the `POST /api/admin/console/exec` endpoint.
+
+- `help` – list available commands.
+- `char:move <character_id> --x INT --y INT [--note NOTE | --snap-to-spawn | --town TOWN_ID]`
+
+### DB CLI Commands
+Run `python db_cli.py <command>`.
+
+Users/Characters:
+- `users`, `user`, `characters`
+
+DB Inspection:
+- `tables`, `head`, `sql`, `export`
+
+Items/Inventory:
+- `items`, `item`, `item-upsert`, `instances`, `mint`, `inventory`, `grant`,
+  `validate-items`, `items-export`, `items-import`, `bulk-grant`
+
+World & Gameplay Helpers:
+- `seed-world`, `list-shards`, `seed-starter`, `quest-reset`
+
+## Demo Warrior Scenario
+1. `python db_cli.py seed-starter`
 2. Start the Flask server: `python app.py`
-3. Open the game in your browser and login.
-4. Create a Warrior via `POST /api/game/characters` or use the UI.
-5. Spawn at coordinates (12,15) and note the Enter Town option.
+3. Open the game and log in.
+4. Create a Warrior (`POST /api/game/characters` or via UI).
+5. Spawn at (12,15) and note the Enter Town option.
 6. Enter the town and explore the 3x3 grid.
-7. Find the shady figure and talk to accept the letter quest.
+7. Find the shady figure and accept the letter quest.
 8. Leave town and move to (13,12) to trigger the goblin ambush.
 9. Defeat the goblins, then travel to (14,9) to meet the Harbormaster.
 10. Talk to the Harbormaster to complete the quest.


### PR DESCRIPTION
## Summary
- Document setup steps for running the server
- List admin UIs, API endpoints, console commands, and DB CLI utilities
- Retain demo warrior scenario instructions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7673063fc832d84cb69d42018b5fb