### PR TITLE
Allow admin role to bypass passphrase

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ To access admin features set an admin passphrase before running the server:
 export ADMIN_PANEL_PASSWORD="your-passphrase"
 ```
 
+Logged-in users whose `role` is `admin` or `dev` skip the passphrase screen and
+are automatically issued an admin token when visiting `/admin/login`.
+
 ## Admin Interfaces
 
 ### UIs

--- a/app/admin_panel.py
+++ b/app/admin_panel.py
@@ -1,6 +1,9 @@
 # app/admin_panel.py
 from flask import Blueprint, request, render_template, redirect, url_for, make_response, current_app, jsonify
+from flask_login import current_user
+
 from .security import issue_admin_token, admin_required
+from .security_rbac import role_gte
 
 admin_ui = Blueprint("admin_ui", __name__)
 
@@ -12,17 +15,45 @@ def _admin_pwd() -> str:
 
 @admin_ui.route("/admin/login", methods=["GET", "POST"])
 def admin_login():
+    def _auto_login():
+        """Grant admin token if current session user has an admin role."""
+        if current_user and getattr(current_user, "is_authenticated", False):
+            if role_gte(getattr(current_user, "role", "user"), "admin"):
+                token = issue_admin_token(
+                    uid=getattr(current_user, "user_id", "ops"),
+                    scopes=["admin"],
+                    ttl=60 * 60 * 8,
+                )
+                resp = make_response(redirect(url_for("admin_ui.admin_panel")))
+                resp.set_cookie(
+                    "admin_token",
+                    token,
+                    max_age=60 * 60 * 8,
+                    httponly=True,
+                    samesite="Lax",
+                    secure=False,
+                )
+                return resp
+        return None
+
     if request.method == "GET":
+        resp = _auto_login()
+        if resp:
+            return resp
         return render_template("admin_login.html")
+
     # POST
+    resp = _auto_login()
+    if resp:
+        return resp
     pwd = request.form.get("password", "")
     if not _admin_pwd() or pwd != _admin_pwd():
         return render_template("admin_login.html", error="Invalid passphrase."), 401
     # scopes you can expand later (e.g., ["vault.read","forge.write"])
-    token = issue_admin_token(uid="ops", scopes=["admin"], ttl=60*60*8)
+    token = issue_admin_token(uid="ops", scopes=["admin"], ttl=60 * 60 * 8)
     resp = make_response(redirect(url_for("admin_ui.admin_panel")))
     resp.set_cookie(
-        "admin_token", token, max_age=60*60*8, httponly=True, samesite="Lax", secure=False
+        "admin_token", token, max_age=60 * 60 * 8, httponly=True, samesite="Lax", secure=False
     )
     return resp
 


### PR DESCRIPTION
## Summary
- issue admin tokens automatically when logged-in users have role `admin` or `dev`
- document auto-login behavior for admin panel

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7715980c8832db97e07c0e93eeacc