### PR TITLE
Add inventory models, API, and demo UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,22 @@ World & Gameplay Helpers:
 8. Leave town and move to (13,12) to trigger the goblin ambush.
 9. Defeat the goblins, then travel to (14,9) to meet the Harbormaster.
 10. Talk to the Harbormaster to complete the quest.
+
+## Inventory API & UI Demo
+
+This repo now includes a tiny inventory system wired end-to-end.
+
+### Setup
+1. Apply migrations (uses SQLite by default):
+   ```
+   FLASK_APP=app.py flask db upgrade
+   ```
+2. Start the development server:
+   ```
+   python app.py
+   ```
+3. Visit [http://localhost:5000/mvp](http://localhost:5000/mvp).
+4. A panel near the bottom shows the inventory for `demo-character-id`.
+   Use the **Add Potion** and **Remove Potion** buttons to test the
+   `/api/characters/<id>/inventory` endpoints.
+

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -18,6 +18,7 @@ from .api_items import api as api_items_bp
 from .api_admin import admin_api
 from .security import admin_guard
 from .admin_panel import admin_ui
+from .api_inventory import bp as inventory_api_bp
 
 def _json_column_type_for(engine) -> str:
     return "TEXT" if engine.dialect.name == "sqlite" else "JSON"
@@ -138,6 +139,7 @@ def create_app():
     app.register_blueprint(api_items_bp, url_prefix="/api", name="items_api")
     app.register_blueprint(admin_api)
     app.register_blueprint(admin_ui)
+    app.register_blueprint(inventory_api_bp)
 
     # Gameplay API
     try:

--- a/app/api_inventory.py
+++ b/app/api_inventory.py
@@ -1,0 +1,156 @@
+"""Simple inventory API used by the demo UI.
+
+Routes live under ``/api`` and work with the ``Item`` and ``InventoryItem``
+models defined for this prototype.
+"""
+from flask import Blueprint, jsonify, request
+from sqlalchemy import case
+
+from .models.base import db
+from .models.characters import Character
+from .models.item import Item
+from .models.inventory_item import InventoryItem
+
+
+bp = Blueprint("inventory_api", __name__, url_prefix="/api")
+
+# rarity order for sorting; earlier in list = more common
+RARITY_ORDER = ["common", "uncommon", "rare", "epic", "legendary"]
+
+
+def _serialize_inventory(rows):
+    """Turn joined ``InventoryItem`` rows into JSON serializable dicts."""
+    items = []
+    for row in rows:
+        itm = row.item
+        items.append(
+            {
+                "item_id": itm.id,
+                "slug": itm.slug,
+                "display_name": itm.display_name,
+                "icon_url": itm.icon_url,
+                "quantity": row.quantity,
+                "stackable": itm.stackable,
+                "max_stack": itm.max_stack,
+                "rarity": itm.rarity,
+                "description": itm.description,
+            }
+        )
+    return items
+
+
+def _rarity_sort():
+    """Return a SQLAlchemy CASE expression for rarity ordering."""
+    return case({r: i for i, r in enumerate(RARITY_ORDER)}, value=Item.rarity)
+
+
+@bp.get("/characters/<character_id>/inventory")
+def get_inventory(character_id: str):
+    """Return the character's inventory in JSON form."""
+    char = db.session.get(Character, character_id)
+    if not char:
+        return jsonify(error="Character not found"), 404
+
+    rows = (
+        InventoryItem.query.join(Item)
+        .filter(InventoryItem.character_id == character_id)
+        .order_by(_rarity_sort(), Item.display_name)
+        .all()
+    )
+    return jsonify({"character_id": character_id, "items": _serialize_inventory(rows)})
+
+
+@bp.post("/characters/<character_id>/inventory/add")
+def add_item(character_id: str):
+    """Give the character more of an item."""
+    char = db.session.get(Character, character_id)
+    if not char:
+        return jsonify(error="Character not found"), 404
+
+    data = request.get_json(force=True, silent=True) or {}
+    slug = data.get("item_slug")
+    qty = int(data.get("quantity", 1))
+
+    item = Item.query.filter_by(slug=slug).first()
+    if not item:
+        return jsonify(error="item_slug not found"), 400
+
+    entry = InventoryItem.query.filter_by(
+        character_id=character_id, item_id=item.id
+    ).first()
+
+    capped = False
+    if item.stackable:
+        new_qty = qty
+        if entry:
+            new_qty += entry.quantity
+        if new_qty > item.max_stack:
+            new_qty = item.max_stack
+            capped = True
+        if entry:
+            entry.quantity = new_qty
+        else:
+            entry = InventoryItem(
+                character_id=character_id, item_id=item.id, quantity=new_qty
+            )
+            db.session.add(entry)
+    else:
+        if entry:
+            entry.quantity = 1
+        else:
+            entry = InventoryItem(
+                character_id=character_id, item_id=item.id, quantity=1
+            )
+            db.session.add(entry)
+
+    db.session.commit()
+
+    payload = {
+        "character_id": character_id,
+        "items": _serialize_inventory(
+            InventoryItem.query.join(Item)
+            .filter(InventoryItem.character_id == character_id)
+            .order_by(_rarity_sort(), Item.display_name)
+            .all()
+        ),
+    }
+    if capped:
+        payload["capped"] = True
+    return jsonify(payload)
+
+
+@bp.post("/characters/<character_id>/inventory/remove")
+def remove_item(character_id: str):
+    """Remove quantity of an item from the character."""
+    char = db.session.get(Character, character_id)
+    if not char:
+        return jsonify(error="Character not found"), 404
+
+    data = request.get_json(force=True, silent=True) or {}
+    slug = data.get("item_slug")
+    qty = int(data.get("quantity", 1))
+
+    item = Item.query.filter_by(slug=slug).first()
+    if not item:
+        return jsonify(error="item_slug not found"), 400
+
+    entry = InventoryItem.query.filter_by(
+        character_id=character_id, item_id=item.id
+    ).first()
+    if not entry:
+        return jsonify(error="Item not in inventory"), 400
+
+    entry.quantity -= qty
+    if entry.quantity <= 0:
+        db.session.delete(entry)
+
+    db.session.commit()
+
+    rows = (
+        InventoryItem.query.join(Item)
+        .filter(InventoryItem.character_id == character_id)
+        .order_by(_rarity_sort(), Item.display_name)
+        .all()
+    )
+    return jsonify({"character_id": character_id, "items": _serialize_inventory(rows)})
+

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -5,6 +5,8 @@ from .users import User                      # noqa: F401
 from .characters import Character            # noqa: F401
 from .items import Item                      # noqa: F401
 from .inventory import ItemInstance, CharacterInventory   # noqa: F401
+from .item import Item as ItemV1             # noqa: F401
+from .inventory_item import InventoryItem    # noqa: F401
 # Gameplay models
 from .gameplay import (
     Town, TownRoom, NPC, Quest, QuestState, CharacterState, EncounterTrigger,
@@ -16,6 +18,7 @@ __all__ = [
     "db", "Model", "metadata",
     "User", "Character",
     "Item", "ItemInstance", "CharacterInventory",
+    "ItemV1", "InventoryItem",
     "Town", "TownRoom", "NPC", "Quest", "QuestState", "CharacterState", "EncounterTrigger",
     "AdminAuditLog",
     # "Recipe",

--- a/app/models/characters.py
+++ b/app/models/characters.py
@@ -44,4 +44,9 @@ class Character(Model):
     )
     last_seen_at = db.Column(db.DateTime)
 
-
+    # link to items this character carries
+    inventory_items = db.relationship(
+        "InventoryItem",
+        back_populates="character",
+        cascade="all, delete-orphan",
+    )

--- a/app/models/inventory_item.py
+++ b/app/models/inventory_item.py
@@ -1,0 +1,25 @@
+"""Join table linking characters to the items they carry."""
+
+from .base import db, Model
+
+
+class InventoryItem(Model):
+    __tablename__ = "inventory_items"
+
+    id = db.Column(db.Integer, primary_key=True)
+    character_id = db.Column(
+        db.String, db.ForeignKey("character.character_id"), nullable=False
+    )
+    item_id = db.Column(
+        db.Integer, db.ForeignKey("items_v1.id"), nullable=False
+    )
+    quantity = db.Column(db.Integer, nullable=False, default=1)
+
+    # relationships give us convenient access to related rows
+    character = db.relationship("Character", back_populates="inventory_items")
+    item = db.relationship("app.models.item.Item", back_populates="inventory_entries")
+
+    __table_args__ = (
+        db.UniqueConstraint("character_id", "item_id", name="uq_character_item"),
+    )
+

--- a/app/models/item.py
+++ b/app/models/item.py
@@ -1,0 +1,30 @@
+"""Basic item model used for the inventory system.
+
+Each row describes an item type (like "iron-sword").
+Players hold references to these items in their inventory rows.
+Comments keep explanations simple for younger readers.
+"""
+
+from .base import db, Model
+
+
+class Item(Model):
+    __tablename__ = "items_v1"
+
+    id = db.Column(db.Integer, primary_key=True)
+    slug = db.Column(db.String(64), unique=True, index=True, nullable=False)
+    display_name = db.Column(db.String(120), nullable=False)
+    icon_url = db.Column(db.String(256), nullable=False)
+    stackable = db.Column(db.Boolean, nullable=False, default=True)
+    max_stack = db.Column(db.Integer, nullable=False, default=99)
+    rarity = db.Column(db.String(16), nullable=False, default="common")
+    description = db.Column(db.Text)
+
+    # allow reverse lookups: item -> inventory rows
+    inventory_entries = db.relationship(
+        "InventoryItem", back_populates="item", cascade="all, delete-orphan"
+    )
+
+    def __repr__(self) -> str:  # helpful for debugging
+        return f"<Item {self.slug}>"
+

--- a/migrations/versions/b5f7a1c9e6d4_create_inventory_tables.py
+++ b/migrations/versions/b5f7a1c9e6d4_create_inventory_tables.py
@@ -1,0 +1,58 @@
+"""create item and inventory_item tables"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "b5f7a1c9e6d4"
+down_revision = "9b07fd5d213a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "items_v1",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("slug", sa.String(length=64), nullable=False),
+        sa.Column("display_name", sa.String(length=120), nullable=False),
+        sa.Column("icon_url", sa.String(length=256), nullable=False),
+        sa.Column(
+            "stackable", sa.Boolean(), nullable=False, server_default=sa.text("1")
+        ),
+        sa.Column(
+            "max_stack", sa.Integer(), nullable=False, server_default=sa.text("99")
+        ),
+        sa.Column(
+            "rarity",
+            sa.String(length=16),
+            nullable=False,
+            server_default=sa.text("'common'"),
+        ),
+        sa.Column("description", sa.Text(), nullable=True),
+    )
+    op.create_index(
+        op.f("ix_items_v1_slug"), "items_v1", ["slug"], unique=True
+    )
+
+    op.create_table(
+        "inventory_items",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "character_id", sa.String(), sa.ForeignKey("character.character_id"), nullable=False
+        ),
+        sa.Column(
+            "item_id", sa.Integer(), sa.ForeignKey("items_v1.id"), nullable=False
+        ),
+        sa.Column(
+            "quantity", sa.Integer(), nullable=False, server_default=sa.text("1")
+        ),
+        sa.UniqueConstraint("character_id", "item_id", name="uq_character_item"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("inventory_items")
+    op.drop_index(op.f("ix_items_v1_slug"), table_name="items_v1")
+    op.drop_table("items_v1")
+

--- a/migrations/versions/d4b5d8f83c21_seed_inventory_data.py
+++ b/migrations/versions/d4b5d8f83c21_seed_inventory_data.py
@@ -1,0 +1,131 @@
+"""seed demo items and a sample character inventory"""
+
+from alembic import op
+import sqlalchemy as sa
+import datetime as dt
+
+
+revision = "d4b5d8f83c21"
+down_revision = "b5f7a1c9e6d4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    now = dt.datetime.utcnow()
+
+    items_table = sa.table(
+        "items_v1",
+        sa.column("id", sa.Integer),
+        sa.column("slug", sa.String),
+        sa.column("display_name", sa.String),
+        sa.column("icon_url", sa.String),
+        sa.column("stackable", sa.Boolean),
+        sa.column("max_stack", sa.Integer),
+        sa.column("rarity", sa.String),
+        sa.column("description", sa.Text),
+    )
+    op.bulk_insert(
+        items_table,
+        [
+            {
+                "id": 1,
+                "slug": "iron-sword",
+                "display_name": "Iron Sword",
+                "icon_url": "/static/assets/items/iron_sword.png",
+                "stackable": False,
+                "max_stack": 1,
+                "rarity": "common",
+                "description": "A sturdy iron blade.",
+            },
+            {
+                "id": 2,
+                "slug": "health-potion",
+                "display_name": "Health Potion",
+                "icon_url": "/static/assets/items/health_potion.png",
+                "stackable": True,
+                "max_stack": 20,
+                "rarity": "common",
+                "description": "Restores a small amount of HP.",
+            },
+            {
+                "id": 3,
+                "slug": "oak-wood",
+                "display_name": "Oak Wood",
+                "icon_url": "/static/assets/items/oak_wood.png",
+                "stackable": True,
+                "max_stack": 99,
+                "rarity": "common",
+                "description": "A piece of oak wood.",
+            },
+        ],
+    )
+
+    users_table = sa.table(
+        "users",
+        sa.column("user_id", sa.String),
+        sa.column("email", sa.String),
+        sa.column("is_active", sa.Boolean),
+        sa.column("created_at", sa.DateTime),
+        sa.column("updated_at", sa.DateTime),
+    )
+    op.bulk_insert(
+        users_table,
+        [
+            {
+                "user_id": "demo-user",
+                "email": "demo@example.com",
+                "is_active": True,
+                "created_at": now,
+                "updated_at": now,
+            }
+        ],
+    )
+
+    chars_table = sa.table(
+        "character",
+        sa.column("character_id", sa.String),
+        sa.column("user_id", sa.String),
+        sa.column("name", sa.String),
+        sa.column("is_deleted", sa.Boolean),
+        sa.column("is_active", sa.Boolean),
+        sa.column("created_at", sa.DateTime),
+        sa.column("updated_at", sa.DateTime),
+    )
+    op.bulk_insert(
+        chars_table,
+        [
+            {
+                "character_id": "demo-character-id",
+                "user_id": "demo-user",
+                "name": "Demo Hero",
+                "is_deleted": False,
+                "is_active": True,
+                "created_at": now,
+                "updated_at": now,
+            }
+        ],
+    )
+
+    inv_table = sa.table(
+        "inventory_items",
+        sa.column("character_id", sa.String),
+        sa.column("item_id", sa.Integer),
+        sa.column("quantity", sa.Integer),
+    )
+    op.bulk_insert(
+        inv_table,
+        [
+            {"character_id": "demo-character-id", "item_id": 1, "quantity": 1},
+            {"character_id": "demo-character-id", "item_id": 2, "quantity": 5},
+            {"character_id": "demo-character-id", "item_id": 3, "quantity": 12},
+        ],
+    )
+
+
+def downgrade() -> None:
+    op.execute("DELETE FROM inventory_items WHERE character_id='demo-character-id'")
+    op.execute("DELETE FROM character WHERE character_id='demo-character-id'")
+    op.execute("DELETE FROM users WHERE user_id='demo-user'")
+    op.execute("DELETE FROM items_v1 WHERE id IN (1,2,3)")
+

--- a/static/js/mvp3.js
+++ b/static/js/mvp3.js
@@ -6,6 +6,7 @@ import { setShard as setRoomShard, assertCanonicalTiles, buildRoom } from '/stat
 import { applyRoomDelta } from '/static/js/roomPatcher.js';
 import { API, autosaveCharacterState } from '/static/js/api.js';
 import { updateActionHUD } from '/static/js/actionHud.js';
+import { initInventoryPanel, addItem as addInvItem, removeItem as removeInvItem } from '../src/ui/inventoryPanel.js';
 
 const QS = new URLSearchParams(location.search);
 const DEV_MODE = QS.has('devmode');
@@ -389,3 +390,18 @@ setInterval(() => {
   if (window.__lastShard?.meta?.name) payload.shard_id = window.__lastShard.meta.name;
   autosaveCharacterState(payload).catch(() => { /* swallow in UI */ });
 }, 60_000);
+
+// Inventory panel demo wiring
+document.addEventListener('DOMContentLoaded', () => {
+  const characterId = window.SHARDBOUND?.characterId || 'demo-character-id';
+  const mount = document.getElementById('inventory-root');
+  if (mount) {
+    initInventoryPanel({ characterId, mountEl: mount });
+  }
+  document.getElementById('btn-add-potion')?.addEventListener('click', () => {
+    addInvItem(characterId, 'health-potion', 1);
+  });
+  document.getElementById('btn-remove-potion')?.addEventListener('click', () => {
+    removeInvItem(characterId, 'health-potion', 1);
+  });
+});

--- a/static/src/ui/inventoryPanel.css
+++ b/static/src/ui/inventoryPanel.css
@@ -1,0 +1,58 @@
+.inventory-panel {
+  padding: 8px;
+  background: #f5f0e6;
+  border: 1px solid #c9b79c;
+  max-width: 300px;
+  font-family: sans-serif;
+}
+
+.inventory-header {
+  font-weight: bold;
+  margin-bottom: 6px;
+}
+
+.inventory-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(48px, 1fr));
+  gap: 4px;
+}
+
+.inv-slot {
+  position: relative;
+  width: 48px;
+  height: 48px;
+  border: 2px solid #bbb;
+  background: rgba(255,255,255,0.6);
+}
+
+.inventory-icon {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.qty-badge {
+  position: absolute;
+  bottom: -4px;
+  right: -4px;
+  background: rgba(0,0,0,0.75);
+  color: #fff;
+  font-size: 10px;
+  padding: 1px 4px;
+  border-radius: 8px;
+}
+
+/* rarity borders */
+.rarity-common { border-color: #bbb; }
+.rarity-uncommon { border-color: #4caf50; }
+.rarity-rare { border-color: #2196f3; }
+.rarity-epic { border-color: #9c27b0; }
+.rarity-legendary { border-color: #ff9800; }
+
+.empty-msg {
+  grid-column: 1 / -1;
+  text-align: center;
+  font-size: 14px;
+  color: #555;
+}
+

--- a/static/src/ui/inventoryPanel.js
+++ b/static/src/ui/inventoryPanel.js
@@ -1,0 +1,87 @@
+// Simple inventory panel for the demo. Uses only browser features.
+
+let _mount = null;
+let _charId = null;
+
+// Fetch and render the inventory grid
+export async function initInventoryPanel({ characterId, mountEl }) {
+  _charId = characterId;
+  _mount = mountEl;
+  await refreshInventory(characterId);
+}
+
+export async function refreshInventory(characterId = _charId) {
+  if (!_mount) return;
+  const res = await fetch(`/api/characters/${characterId}/inventory`);
+  const data = await res.json();
+  render(data.items || []);
+  return data;
+}
+
+export async function addItem(characterId, itemSlug, qty = 1) {
+  await fetch(`/api/characters/${characterId}/inventory/add`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ item_slug: itemSlug, quantity: qty })
+  });
+  return refreshInventory(characterId);
+}
+
+export async function removeItem(characterId, itemSlug, qty = 1) {
+  await fetch(`/api/characters/${characterId}/inventory/remove`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ item_slug: itemSlug, quantity: qty })
+  });
+  return refreshInventory(characterId);
+}
+
+function render(items) {
+  _mount.innerHTML = '';
+  const panel = document.createElement('div');
+  panel.className = 'inventory-panel';
+
+  const header = document.createElement('div');
+  header.className = 'inventory-header';
+  header.textContent = 'Inventory';
+  panel.appendChild(header);
+
+  const grid = document.createElement('div');
+  grid.className = 'inventory-grid';
+  panel.appendChild(grid);
+
+  if (items.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'empty-msg';
+    empty.textContent = 'Bag is empty.';
+    grid.appendChild(empty);
+  }
+
+  for (const it of items) {
+    const slot = document.createElement('div');
+    slot.className = `inv-slot rarity-${it.rarity}`;
+
+    const img = document.createElement('img');
+    img.src = it.icon_url;
+    img.alt = it.display_name;
+    img.className = 'inventory-icon';
+    img.title = `${it.display_name} (${it.rarity})\n${it.description || ''}`;
+    img.onerror = () => {
+      img.onerror = null;
+      img.src = '/static/assets/items/_fallback.png';
+    };
+    slot.appendChild(img);
+
+    if (it.quantity > 1) {
+      const badge = document.createElement('span');
+      badge.className = 'qty-badge';
+      badge.textContent = it.quantity;
+      slot.appendChild(badge);
+    }
+
+    grid.appendChild(slot);
+  }
+
+  _mount.appendChild(panel);
+}
+

--- a/templates/mvp3.html
+++ b/templates/mvp3.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/mvp3.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/mapOverlay.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/town.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='src/ui/inventoryPanel.css') }}">
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@600..900&family=IM+Fell+English:ital@0;1&family=Crimson+Text:wght@400;600&display=swap" rel="stylesheet">
 
   <script>window.SHARDBIOME_SOURCE = 'grid';</script>
@@ -136,6 +137,13 @@
 
   <!-- Action Bar mount -->
   <div id="action-root" class="action-root"></div>
+
+  <!-- Inventory panel mount and demo buttons -->
+  <div id="inventory-root"></div>
+  <div style="margin:8px 0;">
+    <button id="btn-add-potion" class="btn">Add Potion</button>
+    <button id="btn-remove-potion" class="btn">Remove Potion</button>
+  </div>
 
   <!-- ES modules -->
   <script type="module" src="{{ url_for('static', filename='js/mvp3.js') }}"></script>


### PR DESCRIPTION
## Summary
- define Item and InventoryItem models and seed demo data via migrations
- expose inventory CRUD endpoints under /api/characters/<id>/inventory
- add simple JS inventory panel with rarity styling and buttons

## Testing
- `FLASK_APP=app.py AUTO_CREATE_TABLES=0 flask db upgrade`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7891ce144832db06cb12f74cb3014