### PR TITLE
feat: add basic console UI module

### DIFF
--- a/static/js/mvp3.js
+++ b/static/js/mvp3.js
@@ -7,6 +7,7 @@ import { applyRoomDelta } from '/static/js/roomPatcher.js';
 import { API, autosaveCharacterState } from '/static/js/api.js';
 import { updateActionHUD } from '/static/js/actionHud.js';
 import { initInventoryPanel, addItem as addInvItem, removeItem as removeInvItem } from '../src/ui/inventoryPanel.js';
+import { mountConsole, print as consolePrint, setPrompt as consoleSetPrompt, setStatus as consoleSetStatus, bindHotkeys as consoleBindHotkeys } from '../src/console/consoleUI.js';
 
 const QS = new URLSearchParams(location.search);
 const DEV_MODE = QS.has('devmode');
@@ -37,14 +38,17 @@ const roomTitle    = document.getElementById('roomTitle');
 const roomBiome    = document.getElementById('roomBiome');
 const roomArt      = document.getElementById('roomArt');
 
-const consoleEl    = document.getElementById('console');
-const cmdInput     = document.getElementById('cmd');
-const cmdSend      = document.getElementById('cmdSend');
 
 const statHP       = document.getElementById('statHP');
 const statMP       = document.getElementById('statMP');
 const statSTA      = document.getElementById('statSTA');
 const statHunger   = document.getElementById('statHunger');
+const consoleRoot  = document.getElementById('console-root');
+mountConsole(consoleRoot);
+consoleBindHotkeys();
+window.consolePrint = consolePrint;
+window.consoleSetPrompt = consoleSetPrompt;
+window.consoleSetStatus = consoleSetStatus;
 
 function updateCharHud(p = {}){
   if(statHP && Number.isFinite(p.hp) && Number.isFinite(p.max_hp)){
@@ -69,12 +73,10 @@ window.updateCharHud = updateCharHud;
 const _log = [];
 function log(text, cls='', ts=null){
   const stamp = new Date(ts || Date.now()).toLocaleTimeString();
-  _log.push({text:`[${stamp}] ${text}`,cls});
-  if (_log.length>300) _log.shift();
-  if (!consoleEl) return;
-  const frag = document.createDocumentFragment();
-  for (const {text:t,cls:c} of _log.slice(-140)) { const d=document.createElement('div'); d.className='line'+(c?' '+c:''); d.textContent=t; frag.appendChild(d); }
-  consoleEl.replaceChildren(frag);
+  const line = `[${stamp}] ${text}`;
+  _log.push({ text: line, cls });
+  if (_log.length > 300) _log.shift();
+  consolePrint(line, { mode: cls ? 'system' : 'normal' });
 }
 
 // ---- overlay instance (visuals live in overlayMap.js) ----

--- a/static/src/console/consoleUI.js
+++ b/static/src/console/consoleUI.js
@@ -1,0 +1,137 @@
+// consoleUI.js - simple in-page console UI
+// Exports: mountConsole, print, setPrompt, setStatus, bindHotkeys
+// Basic CSS (optional):
+/*
+#console-root {
+  font-family: monospace;
+  background: #000;
+  color: #eee;
+}
+#console-root .scrollback {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px;
+}
+#console-root .input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 4px;
+  border: none;
+  outline: none;
+}
+#console-root .status {
+  font-size: 12px;
+  padding: 2px 4px;
+  background: #111;
+}
+#console-root .system {
+  color: #6cf;
+}
+*/
+
+let rootEl, scrollEl, inputEl, statusEl;
+const history = [];
+let histIndex = 0;
+
+// mountConsole(rootElement)
+// Creates console structure inside rootElement
+export function mountConsole(root) {
+  if (!root) return;
+  rootEl = root;
+  rootEl.style.display = 'flex';
+  rootEl.style.flexDirection = 'column';
+  rootEl.style.height = '200px';
+  rootEl.style.background = '#000';
+  rootEl.style.color = '#eee';
+  rootEl.style.fontFamily = 'monospace';
+
+  scrollEl = document.createElement('div');
+  scrollEl.className = 'scrollback';
+  scrollEl.style.flex = '1';
+  scrollEl.style.overflowY = 'auto';
+  scrollEl.style.padding = '4px';
+
+  inputEl = document.createElement('input');
+  inputEl.type = 'text';
+  inputEl.className = 'input';
+  inputEl.style.width = '100%';
+  inputEl.style.boxSizing = 'border-box';
+  inputEl.style.padding = '4px';
+  inputEl.style.border = 'none';
+  inputEl.style.outline = 'none';
+  inputEl.addEventListener('keydown', handleKey); // key events
+
+  statusEl = document.createElement('div');
+  statusEl.className = 'status';
+  statusEl.style.fontSize = '12px';
+  statusEl.style.padding = '2px 4px';
+  statusEl.style.background = '#111';
+
+  rootEl.replaceChildren(scrollEl, inputEl, statusEl);
+}
+
+function handleKey(ev) {
+  if (ev.key === 'Enter') {
+    const val = inputEl.value;
+    if (val.trim()) {
+      print(val);
+      history.push(val);
+      histIndex = history.length;
+    }
+    inputEl.value = '';
+  } else if (ev.key === 'ArrowUp') {
+    if (histIndex > 0) {
+      histIndex--;
+      inputEl.value = history[histIndex] || '';
+    }
+    ev.preventDefault();
+  } else if (ev.key === 'ArrowDown') {
+    if (histIndex < history.length) {
+      histIndex++;
+      inputEl.value = history[histIndex] || '';
+    }
+    ev.preventDefault();
+  }
+}
+
+// print(lines, opts?) -> append line(s) to scrollback
+export function print(lines, opts = {}) {
+  if (!scrollEl) return;
+  const arr = Array.isArray(lines) ? lines : [lines];
+  for (const line of arr) {
+    const d = document.createElement('div');
+    d.textContent = line;
+    if (opts.mode === 'system') d.className = 'system';
+    scrollEl.appendChild(d);
+  }
+  scrollEl.scrollTop = scrollEl.scrollHeight;
+}
+
+// setPrompt(text) -> set placeholder
+export function setPrompt(text) {
+  if (inputEl) inputEl.placeholder = text;
+}
+
+// setStatus(info) -> update status bar
+export function setStatus(info = {}) {
+  if (!statusEl) return;
+  const parts = [];
+  if (info.hp !== undefined) parts.push(`HP:${info.hp}`);
+  if (info.mp !== undefined) parts.push(`MP:${info.mp}`);
+  if (info.coords) parts.push(info.coords);
+  if (info.target) parts.push(`Target:${info.target}`);
+  statusEl.textContent = parts.join(' | ');
+}
+
+// bindHotkeys() -> focus input on '/'
+export function bindHotkeys() {
+  document.addEventListener('keydown', ev => {
+    if (ev.key === '/' && document.activeElement !== inputEl) {
+      ev.preventDefault();
+      inputEl?.focus();
+    }
+  });
+}
+
+// expose for debugging
+export default { mountConsole, print, setPrompt, setStatus, bindHotkeys };

--- a/templates/mvp3.html
+++ b/templates/mvp3.html
@@ -67,16 +67,7 @@
         </div>
       </div>
 
-      <div class="console-wrap">
-        <div id="console" class="console" aria-live="polite">
-          <div class="line dim">Console ready. Use exits or actions.</div>
-        </div>
-
-        <div class="console-input">
-          <input id="cmd" type="text" placeholder="Type a command (e.g., 'move n', 'search') and press Enter…" />
-          <button id="cmdSend" class="btn">Send</button>
-        </div>
-      </div>
+      <div id="console-root" class="console-wrap"></div>
     </section>
   </main>
 


### PR DESCRIPTION
## Summary
- add standalone `consoleUI.js` with print, prompt, status, and hotkey helpers
- mount console UI in `mvp3.js` and expose helper functions globally
- replace old console markup with `#console-root`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7a3d82f78832da32e483876bc8868