### PR TITLE
Add persistent console history and tab completion

### DIFF
--- a/static/src/console/completions.js
+++ b/static/src/console/completions.js
@@ -1,0 +1,16 @@
+// completions.js - simple command completions for the console
+// Exports: complete(prefix, ctx) -> { suggestion: string, list: string[] }
+
+import { list as commandList } from './commandRegistry.js';
+
+export function complete(prefix = '', ctx = {}) {
+  const commands = commandList(ctx);
+  const tokens = [];
+  for (const def of commands) {
+    if (!prefix || def.name.startsWith(prefix)) tokens.push(def.name);
+  }
+  tokens.sort();
+  return { suggestion: tokens[0] || '', list: tokens };
+}
+
+export default { complete };

--- a/static/src/console/consoleUI.js
+++ b/static/src/console/consoleUI.js
@@ -29,9 +29,10 @@
 }
 */
 
-let rootEl, scrollEl, inputEl, statusEl;
-const history = [];
-let histIndex = 0;
+import * as history from './history.js';
+import { complete } from './completions.js';
+
+let rootEl, scrollEl, inputEl, statusEl, compEl;
 
 // mountConsole(rootElement)
 // Creates console structure inside rootElement
@@ -61,13 +62,26 @@ export function mountConsole(root) {
   inputEl.style.outline = 'none';
   inputEl.addEventListener('keydown', handleKey); // key events
 
+  compEl = document.createElement('div');
+  compEl.className = 'completions';
+  compEl.style.position = 'absolute';
+  compEl.style.background = '#111';
+  compEl.style.color = '#eee';
+  compEl.style.fontSize = '12px';
+  compEl.style.padding = '2px 4px';
+  compEl.style.display = 'none';
+  compEl.style.zIndex = '10';
+  compEl.style.left = '4px';
+  compEl.style.bottom = '24px';
+
   statusEl = document.createElement('div');
   statusEl.className = 'status';
   statusEl.style.fontSize = '12px';
   statusEl.style.padding = '2px 4px';
   statusEl.style.background = '#111';
 
-  rootEl.replaceChildren(scrollEl, inputEl, statusEl);
+  rootEl.style.position = 'relative';
+  rootEl.replaceChildren(scrollEl, inputEl, compEl, statusEl);
 }
 
 function handleKey(ev) {
@@ -76,21 +90,27 @@ function handleKey(ev) {
     if (val.trim()) {
       print(val);
       history.push(val);
-      histIndex = history.length;
     }
     inputEl.value = '';
+    compEl.style.display = 'none';
   } else if (ev.key === 'ArrowUp') {
-    if (histIndex > 0) {
-      histIndex--;
-      inputEl.value = history[histIndex] || '';
-    }
+    inputEl.value = history.prev();
     ev.preventDefault();
   } else if (ev.key === 'ArrowDown') {
-    if (histIndex < history.length) {
-      histIndex++;
-      inputEl.value = history[histIndex] || '';
+    inputEl.value = history.next();
+    ev.preventDefault();
+  } else if (ev.key === 'Tab') {
+    const { suggestion, list } = complete(inputEl.value);
+    if (suggestion) inputEl.value = suggestion;
+    if (list.length) {
+      compEl.innerHTML = list.join('<br>');
+      compEl.style.display = 'block';
+    } else {
+      compEl.style.display = 'none';
     }
     ev.preventDefault();
+  } else {
+    compEl.style.display = 'none';
   }
 }
 

--- a/static/src/console/history.js
+++ b/static/src/console/history.js
@@ -1,0 +1,59 @@
+// history.js - persistent console input history using localStorage
+// Exports: push, prev, next, search
+
+const STORAGE_KEY = 'console_history';
+const MAX = 200;
+
+let entries = load();
+let index = entries.length;
+
+function load() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const arr = JSON.parse(raw);
+      if (Array.isArray(arr)) return arr;
+    }
+  } catch (e) {
+    // ignore
+  }
+  return [];
+}
+
+function save() {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  } catch (e) {
+    // ignore
+  }
+}
+
+export function push(line) {
+  if (!line) return;
+  entries.push(line);
+  if (entries.length > MAX) entries = entries.slice(entries.length - MAX);
+  index = entries.length;
+  save();
+}
+
+export function prev() {
+  if (index > 0) index--;
+  return entries[index] || '';
+}
+
+export function next() {
+  if (index < entries.length) index++;
+  return entries[index] || '';
+}
+
+export function search(substr) {
+  for (let i = entries.length - 1; i >= 0; i--) {
+    if (entries[i].includes(substr)) {
+      index = i;
+      return entries[i];
+    }
+  }
+  return '';
+}
+
+export default { push, prev, next, search };


### PR DESCRIPTION
## Summary
- add `history.js` storing up to 200 console entries in `localStorage`
- add `completions.js` to suggest commands based on registry
- wire history navigation and tab completion into `consoleUI.js`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7ab941b1c832da5bf2ba3c9f9ab29