### PR TITLE
Add basic command router and console API endpoint

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -19,6 +19,7 @@ from .api_admin import admin_api
 from .security import admin_guard
 from .admin_panel import admin_ui
 from .api_inventory import bp as inventory_api_bp
+from .api_console import bp as console_api_bp
 
 def _json_column_type_for(engine) -> str:
     return "TEXT" if engine.dialect.name == "sqlite" else "JSON"
@@ -140,6 +141,7 @@ def create_app():
     app.register_blueprint(admin_api)
     app.register_blueprint(admin_ui)
     app.register_blueprint(inventory_api_bp)
+    app.register_blueprint(console_api_bp)
 
     # Gameplay API
     try:

--- a/app/api_console.py
+++ b/app/api_console.py
@@ -1,0 +1,21 @@
+"""API endpoint for console command execution."""
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+from flask_login import login_required, current_user
+
+from .models import db, Character
+import command_router as router
+
+bp = Blueprint("console_api", __name__, url_prefix="/api/console")
+
+
+@bp.post("/run")
+@login_required
+def run_command():
+    data = request.get_json(force=True, silent=True) or {}
+    line = data.get("line", "")
+    char_id = data.get("character_id")
+    character = Character.query.get(char_id) if char_id else None
+    frames = router.route(line, current_user, character, db)
+    return jsonify(frames)

--- a/command_router.py
+++ b/command_router.py
@@ -1,0 +1,98 @@
+"""Simple command router for console commands.
+
+Provides a lightweight registry for server-side console commands and a
+``route`` helper that parses a line of text and executes the resolved command.
+
+This mirrors the lightweight command registry used on the front-end.  The
+implementation here is intentionally small and will be expanded later.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional
+import shlex
+
+CommandExec = Callable[[Dict[str, Any], Dict[str, Any]], List[Dict[str, Any]]]
+
+@dataclass
+class CommandDef:
+    name: str
+    exec: CommandExec
+    aliases: Optional[List[str]] = None
+    description: str | None = None
+
+
+_commands: Dict[str, CommandDef] = {}
+_aliases: Dict[str, str] = {}
+
+
+def register(cmd_def: Dict[str, Any] | CommandDef) -> CommandDef:
+    """Register a command definition."""
+    if isinstance(cmd_def, dict):
+        cmd_def = CommandDef(**cmd_def)
+    if not cmd_def.name:
+        return cmd_def
+    _commands[cmd_def.name] = cmd_def
+    for a in cmd_def.aliases or []:
+        _aliases[a] = cmd_def.name
+    return cmd_def
+
+
+def get(name: str) -> Optional[CommandDef]:
+    """Get a command definition by name (canonical only)."""
+    if not name:
+        return None
+    return _commands.get(name)
+
+
+def resolve(name_or_alias: str) -> Optional[CommandDef]:
+    """Resolve a command name or alias to its definition."""
+    if not name_or_alias:
+        return None
+    name = _aliases.get(name_or_alias, name_or_alias)
+    return get(name)
+
+
+def route(line: str, user: Any, character: Any, db: Any) -> List[Dict[str, Any]]:
+    """Parse ``line`` and execute the resolved command.
+
+    Parameters mirror the front-end schema.  ``user`` and ``character`` are
+    passed through to executor functions via a simple context dict.
+    """
+    if not isinstance(line, str):
+        return [{"type": "text", "data": "Invalid input"}]
+    try:
+        parts = shlex.split(line)
+    except ValueError as e:
+        return [{"type": "text", "data": str(e)}]
+    if not parts:
+        return []
+    token, *args = parts
+    cmd_def = resolve(token)
+    if not cmd_def:
+        return [{"type": "text", "data": f"Unknown command: {token}"}]
+    ctx = {"user": user, "character": character, "db": db}
+    cmd = {"cmd": cmd_def.name, "args": args, "flags": {}}
+    try:
+        frames = cmd_def.exec(cmd, ctx)
+    except Exception as e:  # pragma: no cover - simple safety
+        return [{"type": "text", "data": f"Error: {e}"}]
+    return frames if isinstance(frames, list) else []
+
+
+# --- Default command registrations ---------------------------------------
+from executors import movement, inventory  # noqa: E402
+
+register({
+    "name": "n",
+    "aliases": ["north"],
+    "exec": movement.move,
+    "description": "Move north",
+})
+
+register({
+    "name": "inv",
+    "aliases": ["inventory", "i"],
+    "exec": inventory.inv,
+    "description": "Show inventory",
+})

--- a/executors/__init__.py
+++ b/executors/__init__.py
@@ -1,0 +1,1 @@
+# executors package

--- a/executors/inventory.py
+++ b/executors/inventory.py
@@ -1,0 +1,12 @@
+"""Inventory command executors (stub)."""
+from __future__ import annotations
+from typing import Any, Dict, List
+
+
+def inv(cmd: Dict[str, Any], ctx: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Return a sample inventory table frame."""
+    data = [
+        {"item": "Health Potion", "qty": 2},
+        {"item": "Iron Sword", "qty": 1},
+    ]
+    return [{"type": "table", "data": data}]

--- a/executors/movement.py
+++ b/executors/movement.py
@@ -1,0 +1,13 @@
+"""Movement command executors (stub)."""
+from __future__ import annotations
+from typing import Any, Dict, List
+
+
+def move(cmd: Dict[str, Any], ctx: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Stub movement command.
+
+    Returns a simple text frame indicating movement north. In a full
+    implementation this would update character position based on ``cmd`` and
+    ``ctx``.
+    """
+    return [{"type": "text", "data": "You move north."}]

--- a/tests/test_command_router.py
+++ b/tests/test_command_router.py
@@ -1,0 +1,11 @@
+import command_router as router
+
+
+def test_inv_returns_table_frame():
+    frames = router.route('inv', None, None, None)
+    assert frames and frames[0]['type'] == 'table'
+
+
+def test_n_routes_to_movement_move():
+    frames = router.route('n', None, None, None)
+    assert any(f['type'] == 'text' and 'move north' in f['data'] for f in frames)


### PR DESCRIPTION
## Summary
- add simple command router with register, resolve and routing helpers
- stub executors for movement and inventory commands
- expose `/api/console/run` endpoint invoking the router and register blueprint
- tests for routing of `inv` and `n`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7ac6a8414832d99c0157056334d85