### PR TITLE
Add console execution API endpoint

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -19,6 +19,7 @@ from .api_admin import admin_api
 from .security import admin_guard
 from .admin_panel import admin_ui
 from .api_inventory import bp as inventory_api_bp
+from .api_console import bp as console_api_bp
 
 def _json_column_type_for(engine) -> str:
     return "TEXT" if engine.dialect.name == "sqlite" else "JSON"
@@ -140,6 +141,7 @@ def create_app():
     app.register_blueprint(admin_api)
     app.register_blueprint(admin_ui)
     app.register_blueprint(inventory_api_bp)
+    app.register_blueprint(console_api_bp)
 
     # Gameplay API
     try:

--- a/app/api_console.py
+++ b/app/api_console.py
@@ -1,0 +1,74 @@
+"""Lightweight console execution API.
+
+Provides a single POST `/api/console/exec` endpoint that echoes back
+input lines and stubs out basic commands.  Intended for early console UI
+experiments.
+"""
+from __future__ import annotations
+
+import time
+from collections import defaultdict, deque
+from typing import Deque
+
+from flask import Blueprint, jsonify, request
+from flask_login import login_required, current_user
+
+bp = Blueprint("api_console", __name__, url_prefix="/api/console")
+
+# in-memory per-user rate limiting; not persistent and only suitable for
+# low traffic testing purposes
+_RATE_LIMIT: defaultdict[str, Deque[float]] = defaultdict(deque)
+_MAX_PER_SEC = 5
+_WINDOW = 1.0  # seconds
+
+
+@bp.post("/exec")
+@login_required
+def exec_command():
+    """Execute a console command.
+
+    Input JSON: ``{"line": str, "context": {"character_id": str?, "shard_id": str?}}``
+    Output JSON: ``{"status": "ok"|"error", "frames": [{"type", "data"}], "error": {"message", "code"}}``
+    """
+    data = request.get_json(force=True, silent=True) or {}
+    line = data.get("line")
+    if line is None or not isinstance(line, str):
+        line = ""
+    line = line.strip()
+
+    if len(line) > 512:
+        return (
+            jsonify(
+                {
+                    "status": "error",
+                    "frames": [],
+                    "error": {"message": "Line too long", "code": "line_too_long"},
+                }
+            ),
+            400,
+        )
+
+    # simple per-user rate limiting (5 requests per second window)
+    user_id = str(current_user.get_id())
+    now = time.monotonic()
+    q = _RATE_LIMIT[user_id]
+    while q and now - q[0] > _WINDOW:
+        q.popleft()
+    if len(q) >= _MAX_PER_SEC:
+        return (
+            jsonify(
+                {
+                    "status": "error",
+                    "frames": [],
+                    "error": {"message": "Rate limit exceeded", "code": "rate_limit"},
+                }
+            ),
+            429,
+        )
+    q.append(now)
+
+    frames = [{"type": "text", "data": line}]
+    if line.lower() == "look":
+        frames.append({"type": "text", "data": "You look around. There is nothing of note."})
+
+    return jsonify({"status": "ok", "frames": frames})

--- a/tests/test_api_console.py
+++ b/tests/test_api_console.py
@@ -1,0 +1,40 @@
+import uuid
+from app import create_app
+
+
+def _register(client):
+    email = f"{uuid.uuid4().hex}@t.com"
+    handle = uuid.uuid4().hex[:8]
+    client.post(
+        "/api/auth/register",
+        json={"email": email, "display_name": "P", "handle": handle, "age": 20},
+    )
+
+
+def test_exec_echo_and_look():
+    app = create_app()
+    with app.test_client() as client:
+        _register(client)
+        resp = client.post("/api/console/exec", json={"line": "hello"})
+        data = resp.get_json()
+        assert resp.status_code == 200
+        assert data["status"] == "ok"
+        assert {f["type"] for f in data["frames"]} == {"text"}
+
+        resp = client.post("/api/console/exec", json={"line": "look"})
+        data = resp.get_json()
+        assert len(data["frames"]) >= 2
+        assert data["frames"][1]["type"] == "text"
+
+
+def test_rate_limit():
+    app = create_app()
+    with app.test_client() as client:
+        _register(client)
+        for _ in range(5):
+            r = client.post("/api/console/exec", json={"line": "hi"})
+            assert r.status_code == 200
+        r = client.post("/api/console/exec", json={"line": "hi"})
+        assert r.status_code == 429
+        data = r.get_json()
+        assert data["status"] == "error"


### PR DESCRIPTION
## Summary
- add authenticated `/api/console/exec` endpoint for console experiments
- enforce per-user rate limit and line length validation
- return stub response for `look` command and echo input
- register blueprint in application factory
- cover endpoint with tests including rate limiting

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7adb52300832d95195bf0b6f8f7d5