### PR TITLE
Add server-validated movement and location commands

### DIFF
--- a/command_router.py
+++ b/command_router.py
@@ -82,12 +82,32 @@ def route(line: str, user: Any, character: Any, db: Any) -> List[Dict[str, Any]]
 
 # --- Default command registrations ---------------------------------------
 from executors import movement, inventory  # noqa: E402
+from executors.look import look_cmd, where_cmd  # noqa: E402
+
+for name, alias in (
+    ("n", "north"),
+    ("s", "south"),
+    ("e", "east"),
+    ("w", "west"),
+):
+    register({
+        "name": name,
+        "aliases": [alias],
+        "exec": movement.move,
+        "description": f"Move {alias}",
+    })
 
 register({
-    "name": "n",
-    "aliases": ["north"],
-    "exec": movement.move,
-    "description": "Move north",
+    "name": "look",
+    "aliases": ["l"],
+    "exec": look_cmd,
+    "description": "Look around",
+})
+
+register({
+    "name": "where",
+    "exec": where_cmd,
+    "description": "Show current location",
 })
 
 register({

--- a/executors/look.py
+++ b/executors/look.py
@@ -1,7 +1,7 @@
 """Console look/where executors."""
 from __future__ import annotations
 
-from typing import Dict, List
+from typing import Any, Dict, List
 
 from app.player_service import get_player
 from server.player_engine import can_enter
@@ -67,3 +67,13 @@ def where() -> List[Dict]:
         f"Region: {room_obj.biome}",
     ]
     return [{"type": "text", "data": line} for line in lines]
+
+
+def look_cmd(cmd: Dict[str, Any], ctx: Dict[str, Any]) -> List[Dict]:
+    """Wrapper so ``look`` can be used with :mod:`command_router`."""
+    return look()
+
+
+def where_cmd(cmd: Dict[str, Any], ctx: Dict[str, Any]) -> List[Dict]:
+    """Wrapper so ``where`` can be used with :mod:`command_router`."""
+    return where()

--- a/executors/movement.py
+++ b/executors/movement.py
@@ -1,14 +1,65 @@
-
+"""Movement command executors."""
 from __future__ import annotations
-from typing import Any, Dict, List
+
+from typing import Any, Dict, List, Tuple
+
+from app.player_service import get_player, save_player
+from server.player_engine import move as engine_move
+
+from executors.look import look
+
+try:
+    from app.api.routes import WORLD
+except Exception:  # pragma: no cover
+    from server.world_loader import load_world
+    from pathlib import Path
+    WORLD = load_world(Path("static/public/shards/00089451_test123.json"))
+
+# Direction deltas
+DIRS: Dict[str, Tuple[int, int]] = {
+    "n": (0, -1),
+    "north": (0, -1),
+    "s": (0, 1),
+    "south": (0, 1),
+    "e": (1, 0),
+    "east": (1, 0),
+    "w": (-1, 0),
+    "west": (-1, 0),
+}
+
+
+def _move(dx: int, dy: int) -> List[Dict[str, Any]]:
+    """Shared move implementation returning frame list."""
+    player = get_player()
+    res = engine_move(WORLD, player, dx, dy)
+    frames = [{"type": "text", "data": line} for line in res.get("log", [])]
+    if res.get("ok"):
+        save_player(player)
+    return frames
 
 
 def move(cmd: Dict[str, Any], ctx: Dict[str, Any]) -> List[Dict[str, Any]]:
-    """Stub movement command.
+    """Move the player in the direction specified by ``cmd``."""
+    direction = cmd.get("cmd")
+    if cmd.get("args"):
+        direction = cmd["args"][0]
+    delta = DIRS.get(direction or "")
+    if not delta:
+        return [{"type": "text", "data": "Unknown direction."}]
+    return _move(*delta)
 
-    Returns a simple text frame indicating movement north. In a full
-    implementation this would update character position based on ``cmd`` and
-    ``ctx``.
+
+def move_command(token: str) -> List[Dict[str, Any]]:
+    """Simpler movement helper for ``api_console``.
+
+    ``token`` is expected to be a direction string like ``"n"`` or ``"east"``.
+    Successful moves append a ``look`` after movement to reflect the new room.
     """
-    return [{"type": "text", "data": "You move north."}]
+    delta = DIRS.get(token.lower())
+    if not delta:
+        return [{"type": "text", "data": "Unknown direction."}]
+    frames = _move(*delta)
+    # Show new room on successful move
+    frames.extend(look())
+    return frames
 

--- a/tests/test_command_router.py
+++ b/tests/test_command_router.py
@@ -1,11 +1,21 @@
 import command_router as router
+from app import create_app
+from app.player_service import get_player
 
 
 def test_inv_returns_table_frame():
-    frames = router.route('inv', None, None, None)
-    assert frames and frames[0]['type'] == 'table'
+    app = create_app()
+    with app.test_request_context():
+        frames = router.route('inv', None, None, None)
+        assert frames and frames[0]['type'] == 'table'
 
 
-def test_n_routes_to_movement_move():
-    frames = router.route('n', None, None, None)
-    assert any(f['type'] == 'text' and 'move north' in f['data'] for f in frames)
+def test_move_updates_position_and_look():
+    app = create_app()
+    with app.test_request_context():
+        frames = router.route('s', None, None, None)
+        assert any(f['type'] == 'text' and 'You move' in f['data'] for f in frames)
+        player = get_player()
+        assert player.pos == (0, 1)
+        look_frames = router.route('look', None, None, None)
+        assert any('(0,1)' in f['data'] for f in look_frames)


### PR DESCRIPTION
## Summary
- Implement movement executor with N/S/E/W aliases and server validation
- Add look and where commands showing room details and coordinates
- Register commands and test movement updating character position

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7b06433ac832db392dc358c48d6ca