### PR TITLE
Implement inventory command lifecycle

### DIFF
--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,4 @@
+"""Service layer package."""
+
+__all__: list[str] = []
+

--- a/app/services/items.py
+++ b/app/services/items.py
@@ -1,0 +1,84 @@
+"""Item and inventory helpers."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from app.models import db, Item, CharacterInventory
+
+
+def get_character_inventory(character_id: str) -> List[Dict[str, Any]]:
+    """Return inventory rows for a character."""
+    rows = (
+        CharacterInventory.query.filter_by(character_id=character_id)
+        .order_by(CharacterInventory.slot_index.asc())
+        .all()
+    )
+    out: List[Dict[str, Any]] = []
+    for r in rows:
+        item = db.session.get(Item, r.item_id) if r.item_id else None
+        out.append(
+            {
+                "slot": r.slot_index,
+                "item_id": r.item_id,
+                "name": item.name if item else r.item_id,
+                "qty": r.qty,
+                "equipped": bool(r.equipped),
+            }
+        )
+    return out
+
+
+def inspect_item(item_id: str) -> Optional[Dict[str, Any]]:
+    """Return item info by ``item_id``."""
+    item = db.session.get(Item, item_id)
+    if not item:
+        return None
+    return {
+        "item_id": item.item_id,
+        "name": item.name,
+        "type": item.type,
+        "rarity": item.rarity,
+    }
+
+
+def use_item(character_id: str, item_id: str, qty: int = 1) -> bool:
+    """Consume ``qty`` of ``item_id`` from character's inventory."""
+    row = CharacterInventory.query.filter_by(character_id=character_id, item_id=item_id).first()
+    if not row or row.qty < qty:
+        return False
+    row.qty -= qty
+    if row.qty <= 0:
+        db.session.delete(row)
+    db.session.commit()
+    return True
+
+
+def equip_item(character_id: str, item_id: str) -> bool:
+    """Mark an inventory row as equipped."""
+    row = CharacterInventory.query.filter_by(character_id=character_id, item_id=item_id).first()
+    if not row:
+        return False
+    row.equipped = True
+    db.session.commit()
+    return True
+
+
+def unequip_slot(character_id: str, slot_index: int) -> bool:
+    """Unset the equipped flag for a slot."""
+    row = CharacterInventory.query.filter_by(character_id=character_id, slot_index=slot_index).first()
+    if not row or not row.equipped:
+        return False
+    row.equipped = False
+    db.session.commit()
+    return True
+
+
+__all__ = [
+    "get_character_inventory",
+    "inspect_item",
+    "use_item",
+    "equip_item",
+    "unequip_slot",
+]
+

--- a/command_router.py
+++ b/command_router.py
@@ -116,3 +116,39 @@ register({
     "exec": inventory.inv,
     "description": "Show inventory",
 })
+
+register({
+    "name": "inspect",
+    "exec": inventory.inspect_cmd,
+    "description": "Inspect item",
+})
+
+register({
+    "name": "use",
+    "exec": inventory.use_cmd,
+    "description": "Use item",
+})
+
+register({
+    "name": "equip",
+    "exec": inventory.equip_cmd,
+    "description": "Equip item",
+})
+
+register({
+    "name": "unequip",
+    "exec": inventory.unequip_cmd,
+    "description": "Unequip slot",
+})
+
+register({
+    "name": "drop",
+    "exec": inventory.drop_cmd,
+    "description": "Drop item",
+})
+
+register({
+    "name": "take",
+    "exec": inventory.take_cmd,
+    "description": "Take item",
+})

--- a/executors/inventory.py
+++ b/executors/inventory.py
@@ -1,12 +1,102 @@
-"""Inventory command executors (stub)."""
+"""Inventory command executors."""
+
 from __future__ import annotations
+
 from typing import Any, Dict, List
+
+from app.services import items as item_svc
+
+
+def _require_character(ctx: Dict[str, Any]) -> str | None:
+    """Return character_id from context or ``None`` if missing."""
+    char = ctx.get("character") if ctx else None
+    return getattr(char, "character_id", None) or getattr(char, "id", None)
 
 
 def inv(cmd: Dict[str, Any], ctx: Dict[str, Any]) -> List[Dict[str, Any]]:
-    """Return a sample inventory table frame."""
+    """Return the character's inventory as a table frame."""
+    cid = _require_character(ctx)
+    if not cid:
+        return [{"type": "text", "data": "No character"}]
+    rows = item_svc.get_character_inventory(cid)
     data = [
-        {"item": "Health Potion", "qty": 2},
-        {"item": "Iron Sword", "qty": 1},
+        {
+            "slot": r["slot"],
+            "item": r["name"],
+            "qty": r["qty"],
+            "equipped": "yes" if r["equipped"] else "no",
+        }
+        for r in rows
     ]
     return [{"type": "table", "data": data}]
+
+
+def inspect_cmd(cmd: Dict[str, Any], ctx: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Inspect an item by id."""
+    args = cmd.get("args", []) if cmd else []
+    if not args:
+        return [{"type": "text", "data": "Usage: inspect <item_id>"}]
+    item = item_svc.inspect_item(args[0])
+    if not item:
+        return [{"type": "text", "data": "Item not found"}]
+    text = f"{item['name']} ({item['item_id']})"
+    return [{"type": "text", "data": text}]
+
+
+def use_cmd(cmd: Dict[str, Any], ctx: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Use a consumable item."""
+    cid = _require_character(ctx)
+    args = cmd.get("args", []) if cmd else []
+    if not cid or not args:
+        return [{"type": "text", "data": "Usage: use <item_id>"}]
+    ok = item_svc.use_item(cid, args[0])
+    text = "You use the item." if ok else "Item not available."
+    return [{"type": "text", "data": text}] + inv(cmd, ctx)
+
+
+def equip_cmd(cmd: Dict[str, Any], ctx: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Equip an inventory item."""
+    cid = _require_character(ctx)
+    args = cmd.get("args", []) if cmd else []
+    if not cid or not args:
+        return [{"type": "text", "data": "Usage: equip <item_id>"}]
+    ok = item_svc.equip_item(cid, args[0])
+    text = "Equipped." if ok else "Item not found." 
+    return [{"type": "text", "data": text}] + inv(cmd, ctx)
+
+
+def unequip_cmd(cmd: Dict[str, Any], ctx: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Unequip an item from a slot."""
+    cid = _require_character(ctx)
+    args = cmd.get("args", []) if cmd else []
+    if not cid or not args:
+        return [{"type": "text", "data": "Usage: unequip <slot>"}]
+    try:
+        slot = int(args[0])
+    except ValueError:
+        return [{"type": "text", "data": "Slot must be a number"}]
+    ok = item_svc.unequip_slot(cid, slot)
+    text = "Unequipped." if ok else "Nothing equipped there."
+    return [{"type": "text", "data": text}] + inv(cmd, ctx)
+
+
+def drop_cmd(cmd: Dict[str, Any], ctx: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Placeholder drop command."""
+    return [{"type": "text", "data": "Dropping items not yet implemented."}]
+
+
+def take_cmd(cmd: Dict[str, Any], ctx: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Placeholder take command."""
+    return [{"type": "text", "data": "Taking items not yet implemented."}]
+
+
+__all__ = [
+    "inv",
+    "inspect_cmd",
+    "use_cmd",
+    "equip_cmd",
+    "unequip_cmd",
+    "drop_cmd",
+    "take_cmd",
+]
+

--- a/tests/test_command_router.py
+++ b/tests/test_command_router.py
@@ -1,13 +1,18 @@
 import command_router as router
 from app import create_app
 from app.player_service import get_player
+from app.models import db, Character
 
 
 def test_inv_returns_table_frame():
     app = create_app()
-    with app.test_request_context():
-        frames = router.route('inv', None, None, None)
-        assert frames and frames[0]['type'] == 'table'
+    with app.app_context():
+        char = Character(user_id="u1", name="Tester")
+        db.session.add(char)
+        db.session.commit()
+        with app.test_request_context():
+            frames = router.route('inv', None, char, db.session)
+    assert frames and frames[0]['type'] == 'table'
 
 
 def test_move_updates_position_and_look():

--- a/tests/test_inventory_exec.py
+++ b/tests/test_inventory_exec.py
@@ -1,0 +1,87 @@
+"""Tests for inventory command executors."""
+
+import os
+import tempfile
+
+from app import create_app
+import command_router as router
+from app.models import db, Item, Character, CharacterInventory
+
+
+def _setup_app():
+    fd, path = tempfile.mkstemp()
+    os.close(fd)
+    os.environ["DATABASE_URL"] = f"sqlite:///{path}"
+    app = create_app()
+    return app, path
+
+
+def test_inventory_lifecycle():
+    app, path = _setup_app()
+    try:
+        with app.app_context():
+            char = Character(user_id="u1", name="Hero")
+            db.session.add(char)
+            sword = Item(
+                item_id="sword",
+                item_version="v1",
+                name="Sword",
+                type="weapon",
+                rarity="common",
+                stack_size=1,
+                base_stats={},
+            )
+            potion = Item(
+                item_id="potion",
+                item_version="v1",
+                name="Potion",
+                type="consumable",
+                rarity="common",
+                stack_size=99,
+                base_stats={},
+            )
+            db.session.add_all([sword, potion])
+            db.session.commit()
+
+            inv_sword = CharacterInventory(
+                id="inv1",
+                character_id=char.character_id,
+                slot_index=0,
+                item_id="sword",
+                qty=1,
+            )
+            inv_potion = CharacterInventory(
+                id="inv2",
+                character_id=char.character_id,
+                slot_index=1,
+                item_id="potion",
+                qty=2,
+            )
+            db.session.add_all([inv_sword, inv_potion])
+            db.session.commit()
+
+            with app.test_request_context():
+                router.route("equip sword", None, char, db.session)
+            row = CharacterInventory.query.filter_by(character_id=char.character_id, item_id="sword").first()
+            assert row.equipped is True
+
+            with app.test_request_context():
+                router.route("use potion", None, char, db.session)
+            row_p = CharacterInventory.query.filter_by(character_id=char.character_id, item_id="potion").first()
+            assert row_p.qty == 1
+
+            with app.test_request_context():
+                router.route("unequip 0", None, char, db.session)
+            row = CharacterInventory.query.filter_by(character_id=char.character_id, item_id="sword").first()
+            assert row.equipped is False
+
+            with app.test_request_context():
+                frames = router.route("inv", None, char, db.session)
+            table = next(f for f in frames if f["type"] == "table")["data"]
+            sword_row = next(r for r in table if r["item"] == "Sword")
+            potion_row = next(r for r in table if r["item"] == "Potion")
+            assert sword_row["equipped"] == "no"
+            assert potion_row["qty"] == 1
+    finally:
+        os.remove(path)
+


### PR DESCRIPTION
## Summary
- implement database-backed inventory commands (`inv`, `inspect`, `use`, `equip`, `unequip`)
- add item service helpers for inventory queries and updates
- register new inventory commands in command router and expand tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7b1c88b34832d9cb5a1c1803d3b69