### PR TITLE
Enhance console utilities with history, completions, and tests

### DIFF
--- a/command_router.py
+++ b/command_router.py
@@ -14,6 +14,8 @@ import shlex
 
 CommandExec = Callable[[Dict[str, Any], Dict[str, Any]], List[Dict[str, Any]]]
 
+MAX_LINE_LEN = 512
+
 @dataclass
 class CommandDef:
     name: str
@@ -63,6 +65,8 @@ def route(line: str, user: Any, character: Any, db: Any) -> List[Dict[str, Any]]
     """
     if not isinstance(line, str):
         return [{"type": "text", "data": "Invalid input"}]
+    if len(line) > MAX_LINE_LEN:
+        return [{"type": "text", "data": "Line too long"}]
     try:
         parts = shlex.split(line)
     except ValueError as e:

--- a/static/src/console/__tests__/parser.spec.js
+++ b/static/src/console/__tests__/parser.spec.js
@@ -1,0 +1,44 @@
+import assert from 'assert';
+import { parse } from '../parse.js';
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log('ok -', name);
+  } catch (e) {
+    console.error('fail -', name);
+    console.error(e);
+    process.exitCode = 1;
+  }
+}
+
+test('handles quoted arguments', () => {
+  const res = parse('say "hello world"');
+  assert.deepStrictEqual(res.chain[0].args, ['hello world']);
+});
+
+test('parses flags', () => {
+  const res = parse('attack --target=wolf -k v');
+  assert.deepStrictEqual(res.chain[0].flags, { target: 'wolf', k: 'v' });
+});
+
+test('supports chaining', () => {
+  const res = parse('look; move north');
+  assert.strictEqual(res.chain.length, 2);
+  assert.deepStrictEqual(res.chain.map(c => c.cmd), ['look', 'move']);
+});
+
+test('unknown command still parsed', () => {
+  const res = parse('foobar');
+  assert.strictEqual(res.chain[0].cmd, 'foobar');
+});
+
+test('empty input yields empty chain', () => {
+  const res = parse('   ');
+  assert.deepStrictEqual(res.chain, []);
+});
+
+test('extra semicolons are ignored', () => {
+  const res = parse('look;;;say hi');
+  assert.deepStrictEqual(res.chain.map(c => c.cmd), ['look', 'say']);
+});

--- a/static/src/console/completions.js
+++ b/static/src/console/completions.js
@@ -5,12 +5,22 @@ import { list as commandList } from './commandRegistry.js';
 
 export function complete(prefix = '', ctx = {}) {
   const commands = commandList(ctx);
-  const tokens = [];
+  const tokens = new Set();
   for (const def of commands) {
-    if (!prefix || def.name.startsWith(prefix)) tokens.push(def.name);
+    if (!prefix || def.name.startsWith(prefix)) tokens.add(def.name);
   }
-  tokens.sort();
-  return { suggestion: tokens[0] || '', list: tokens };
+  if (Array.isArray(ctx.items)) {
+    for (const item of ctx.items) {
+      if (!prefix || item.startsWith(prefix)) tokens.add(item);
+    }
+  }
+  if (Array.isArray(ctx.npcs)) {
+    for (const npc of ctx.npcs) {
+      if (!prefix || npc.startsWith(prefix)) tokens.add(npc);
+    }
+  }
+  const list = Array.from(tokens).sort();
+  return { suggestion: list[0] || '', list };
 }
 
 export default { complete };

--- a/static/src/console/consoleUI.js
+++ b/static/src/console/consoleUI.js
@@ -143,6 +143,21 @@ export function setStatus(info = {}) {
   statusEl.textContent = parts.join(' | ');
 }
 
+// renderFrames(frames) -> handle console frames (text/status)
+export function renderFrames(frames = []) {
+  if (!Array.isArray(frames)) return;
+  for (const f of frames) {
+    if (f.type === 'status') {
+      setStatus(f.data);
+    } else if (f.type === 'text') {
+      print(f.data);
+    } else if (f.type === 'table') {
+      const rows = f.data || [];
+      for (const row of rows) print(Object.values(row).join(' '));
+    }
+  }
+}
+
 // bindHotkeys() -> focus input on '/'
 export function bindHotkeys() {
   document.addEventListener('keydown', ev => {
@@ -154,4 +169,4 @@ export function bindHotkeys() {
 }
 
 // expose for debugging
-export default { mountConsole, print, setPrompt, setStatus, bindHotkeys };
+export default { mountConsole, print, setPrompt, setStatus, bindHotkeys, renderFrames };

--- a/static/src/console/history.js
+++ b/static/src/console/history.js
@@ -12,7 +12,13 @@ function load() {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (raw) {
       const arr = JSON.parse(raw);
-      if (Array.isArray(arr)) return arr;
+      if (Array.isArray(arr)) {
+        const out = [];
+        for (const line of arr) {
+          if (out[out.length - 1] !== line) out.push(line);
+        }
+        return out;
+      }
     }
   } catch (e) {
     // ignore
@@ -30,6 +36,10 @@ function save() {
 
 export function push(line) {
   if (!line) return;
+  if (entries[entries.length - 1] === line) {
+    index = entries.length;
+    return;
+  }
   entries.push(line);
   if (entries.length > MAX) entries = entries.slice(entries.length - MAX);
   index = entries.length;

--- a/tests/test_console_router.py
+++ b/tests/test_console_router.py
@@ -1,0 +1,32 @@
+import command_router as router
+from app import create_app
+from app.models import db, Character
+
+
+def test_resolve_alias():
+    assert router.resolve('north').name == 'n'
+
+
+def test_route_inv_returns_table():
+    app = create_app()
+    with app.app_context():
+        char = Character(user_id='u1', name='Tester')
+        db.session.add(char)
+        db.session.commit()
+        with app.test_request_context():
+            frames = router.route('inv', None, char, db.session)
+    assert frames and frames[0]['type'] == 'table'
+
+
+def test_unknown_command_error():
+    frames = router.route('frobnicate', None, None, None)
+    assert frames and frames[0]['type'] == 'text'
+    assert 'Unknown command' in frames[0]['data']
+
+
+def test_length_guard():
+    long_line = 'x' * 513
+    frames = router.route(long_line, None, None, None)
+    assert frames and frames[0]['type'] == 'text'
+    assert 'too long' in frames[0]['data'].lower()
+


### PR DESCRIPTION
## Summary
- Deduplicate and persist console history entries in localStorage
- Enrich console completions with dynamic item and NPC sources
- Render status updates from frames and enforce router line length guard
- Add parser and command router test suites

## Testing
- `node static/src/console/__tests__/parser.spec.js`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7b4af8d70832dbb0c6d4b4ef97402