### PR TITLE
feat: improve shardgate link handling

### DIFF
--- a/templates/shard-viewer-v2.html
+++ b/templates/shard-viewer-v2.html
@@ -203,8 +203,9 @@
     }
     btnPlanV2?.addEventListener('click', (e) => { e.preventDefault(); callPlan(); });
 
-    // Progressive enhancement: load v2 overlay code (cache-busted in dev)
-    import('/static/js/shard-viewer-v2.js?v=debug4').catch((e) => { console.error('[SV2] module import error', e); });
-  </script>
-</body>
+    // Progressive enhancement: load v2 overlay code (cache‑busted in dev)
+    // Bump the debug query param so browsers pick up new builds without a hard refresh.
+    import('/static/js/shard-viewer-v2.js?v=debug5').catch((e) => { console.error('[SV2] module import error', e); });
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- add deterministic shardgate IDs and canonicalize gates on load
- add link mode banner, hover highlights, and ESC/cancel support
- allow editing shardgate links with checkbox UI and prune orphan links on remove
- bust shard-viewer-v2 module cache so UI reflects latest changes

## Testing
- `pytest` *(fails: assert 200 == 429)*

------
https://chatgpt.com/codex/tasks/task_e_68baf487effc832d868334dddbe63508