### PR TITLE
Add responsive layout and styling for client v2

### DIFF
--- a/static/css/client_v2.css
+++ b/static/css/client_v2.css
@@ -1,0 +1,117 @@
+/* Layout for Shardbound client v2 */
+
+body {
+  display: grid;
+  grid-template-columns: 340px 1fr 80px;
+  grid-template-rows: auto 1fr;
+  min-height: 100vh;
+}
+
+body.sidebar-collapsed {
+  grid-template-columns: 0 1fr 80px;
+}
+
+header {
+  grid-column: 1 / -1;
+}
+
+#clientSidebar {
+  grid-row: 2;
+  grid-column: 1;
+  width: 340px;
+  padding: 16px;
+  background: var(--panel);
+  border-right: 1px solid var(--line);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  overflow-y: auto;
+  transition: transform .2s ease;
+}
+
+#clientSidebar.collapsed {
+  transform: translateX(-100%);
+}
+
+#btnSidebarCollapse {
+  position: absolute;
+  top: 8px;
+  right: -12px;
+  width: 24px;
+  height: 24px;
+}
+
+main.viewerMain {
+  grid-row: 2;
+  grid-column: 2;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+#actionRail {
+  grid-row: 2;
+  grid-column: 3;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: center;
+  padding: 16px 8px;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+}
+
+#actionRail button {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+}
+
+#shardStatus {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.console-section {
+  margin-top: 16px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+  color: var(--text);
+}
+
+.console-section summary {
+  padding: 8px;
+  cursor: pointer;
+}
+
+.console-section #console-root {
+  max-height: 200px;
+  overflow-y: auto;
+  padding: 8px;
+}
+
+@media (max-width: 900px) {
+  body {
+    grid-template-columns: 0 1fr 60px;
+  }
+  body.sidebar-collapsed {
+    grid-template-columns: 0 1fr 60px;
+  }
+  body.sidebar-collapsed #clientSidebar {
+    transform: translateX(-100%);
+  }
+  #clientSidebar {
+    transform: translateX(-100%);
+  }
+  #clientSidebar:not(.collapsed) {
+    transform: translateX(0);
+  }
+  #actionRail {
+    grid-column: 3;
+    padding: 8px 4px;
+  }
+}

--- a/templates/client_v2.html
+++ b/templates/client_v2.html
@@ -10,54 +10,11 @@
   <link rel="stylesheet" href="/static/css/shard-viewer-v2.css" />
   <link rel="stylesheet" href="/static/css/inventoryOverlay.css" />
   <link rel="stylesheet" href="/static/css/characterPanel.css" />
+  <link rel="stylesheet" href="/static/css/client_v2.css" />
 
   <script>
     window.SHARDBIOME_SOURCE = 'grid';
   </script>
-
-  <style>
-    /* Layout scaffolding */
-    #clientSidebar {
-      position: fixed;
-      top: 0; bottom: 0; left: 0;
-      width: 240px;
-      padding: 16px;
-      background: var(--panel);
-      border-right: 1px solid var(--line);
-      display: flex;
-      flex-direction: column;
-      gap: 20px;
-      overflow: auto;
-      transition: transform .2s ease;
-    }
-    #clientSidebar.collapsed { transform: translateX(-100%); }
-    #btnSidebarCollapse {
-      position: absolute;
-      top: 8px;
-      right: -12px;
-      width: 24px;
-      height: 24px;
-    }
-    main.viewerMain {
-      margin-left: 240px;
-      margin-right: 80px;
-      padding: 16px;
-      display: flex;
-      justify-content: center;
-    }
-    body.sidebar-collapsed main.viewerMain { margin-left: 0; }
-    #actionRail {
-      position: fixed;
-      right: 16px;
-      top: 50%;
-      transform: translateY(-50%);
-      display: flex;
-      flex-direction: column;
-      gap: 8px;
-    }
-    #actionRail button { width: 60px; height: 60px; }
-    #shardStatus { font-size: 12px; color: var(--muted); }
-  </style>
 </head>
 <body>
   <header>
@@ -114,7 +71,10 @@
           <button class="zbtn" id="btnZoomOut" title="Zoom out">−</button>
         </div>
       </section>
-      <div id="console-root" aria-live="polite"></div>
+      <details id="consoleSection" class="console-section" open>
+        <summary>Console</summary>
+        <div id="console-root" aria-live="polite"></div>
+      </details>
     </section>
   </main>
 
@@ -128,6 +88,15 @@
 
   <div id="action-root" class="action-root"></div>
 
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      if (window.matchMedia('(max-width: 900px)').matches) {
+        document.body.classList.add('sidebar-collapsed');
+        document.getElementById('clientSidebar')?.classList.add('collapsed');
+        document.getElementById('consoleSection')?.removeAttribute('open');
+      }
+    });
+  </script>
   <script type="module" src="/static/js/client_v2.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add dedicated CSS for client v2 with three-zone grid layout, sidebar collapse, action rail, and console styling
- Update client_v2.html to include new stylesheet, wrap console in collapsible section, and auto-collapse sidebar on small screens

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb973d649c832d9de13a12e1ff14ba