### PR TITLE
Refine client v2 layout with right-side quest and journal panels

### DIFF
--- a/static/css/client_v2.css
+++ b/static/css/client_v2.css
@@ -2,13 +2,16 @@
 
 body {
   display: grid;
-  grid-template-columns: 340px 1fr 80px;
+  grid-template-columns: 340px 1fr 80px 300px;
   grid-template-rows: auto 1fr;
   min-height: 100vh;
+  background: #1c1a17;
+  color: var(--text);
+  font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, serif;
 }
 
 body.sidebar-collapsed {
-  grid-template-columns: 0 1fr 80px;
+  grid-template-columns: 0 1fr 80px 300px;
 }
 
 header {
@@ -63,6 +66,24 @@ main.viewerMain {
   height: 100vh;
 }
 
+#rightSidebar {
+  grid-row: 2;
+  grid-column: 4;
+  width: 300px;
+  padding: 16px;
+  background: var(--panel);
+  border-left: 1px solid var(--line);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  overflow-y: auto;
+}
+
+.panel-body {
+  font-size: 14px;
+  line-height: 1.4;
+}
+
 #actionRail button {
   width: 60px;
   height: 60px;
@@ -96,10 +117,10 @@ main.viewerMain {
 
 @media (max-width: 900px) {
   body {
-    grid-template-columns: 0 1fr 60px;
+    grid-template-columns: 0 1fr 60px 0;
   }
   body.sidebar-collapsed {
-    grid-template-columns: 0 1fr 60px;
+    grid-template-columns: 0 1fr 60px 0;
   }
   body.sidebar-collapsed #clientSidebar {
     transform: translateX(-100%);
@@ -113,5 +134,8 @@ main.viewerMain {
   #actionRail {
     grid-column: 3;
     padding: 8px 4px;
+  }
+  #rightSidebar {
+    display: none;
   }
 }

--- a/templates/client_v2.html
+++ b/templates/client_v2.html
@@ -86,6 +86,21 @@
     <button id="btnSkill2">Skill 2</button>
   </div>
 
+  <aside id="rightSidebar">
+    <section class="card" id="cardQuestLog">
+      <h2>Quest Log</h2>
+      <div class="panel-body" id="questLog">No quests available.</div>
+    </section>
+    <section class="card" id="cardJournal">
+      <h2>Journal</h2>
+      <div class="panel-body" id="journal">Your thoughts go here.</div>
+    </section>
+    <section class="card" id="cardPlaceholder">
+      <h2>Mysteries</h2>
+      <div class="panel-body" id="placeholder">Nothing here yet.</div>
+    </section>
+  </aside>
+
   <div id="action-root" class="action-root"></div>
 
   <script>


### PR DESCRIPTION
## Summary
- Add quest log, journal and placeholder sections in a new right sidebar
- Expand grid layout and styling for a D&D-inspired look
- Keep action buttons beside the map for classic gameplay feel

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb9bb619b8832db81067a8126cb1ea