### PR TITLE
Add /play endpoint and integrate with character flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ This repo now includes a tiny inventory system wired end-to-end.
    ```
    python app.py
    ```
-3. Visit [http://localhost:5000/mvp](http://localhost:5000/mvp).
+3. Visit [http://localhost:5000/play](http://localhost:5000/play).
 4. A panel near the bottom shows the inventory for `demo-character-id`.
    Use the **Add Potion** and **Remove Potion** buttons to test the
    `/api/characters/<id>/inventory` endpoints.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -189,6 +189,10 @@ def create_app():
     def mvp():
         return render_template("mvp3.html")
 
+    @app.route("/play")
+    def play():
+        return render_template("mvp3.html")
+
     @app.route("/api-playground")
     def api_playground():
         return render_template("api-playground.html")

--- a/static/js/characters.js
+++ b/static/js/characters.js
@@ -31,7 +31,7 @@ async function bootSelect() {
     `;
     card.querySelector("button").addEventListener("click", async () => {
       await API.characterSelect(c.character_id);
-      location.href = "/mvp";
+      location.href = "/play";
     });
     deck.appendChild(card);
   });
@@ -54,9 +54,12 @@ async function bootCreate() {
     };
     const msg = el("msg");
     try {
-      await API.characterCreate(payload);
+      const res = await API.characterCreate(payload);
       msg.textContent = "Created!";
-      location.href = "/mvp";
+      if (res?.character_id) {
+        try { await API.characterSelect(res.character_id); } catch {}
+      }
+      location.href = "/play";
     } catch (err) {
       msg.textContent = err.message || "Failed to create character";
     }

--- a/templates/character_create.html
+++ b/templates/character_create.html
@@ -173,9 +173,12 @@
           };
           if(!payload.name){ alert('Name required'); return; }
           // Create character via gameplay API; server will grant loadout
-          await api('/api/game/characters',{method:'POST',headers:{'Content-Type':'application/json'},body: JSON.stringify(payload)});
-          // send them to select page so they can pick and play
-          window.location.href = '/characters';
+          const newChar = await api('/api/game/characters',{method:'POST',headers:{'Content-Type':'application/json'},body: JSON.stringify(payload)});
+          // auto-select new character then start playing
+          try {
+            await api('/api/game/characters/select',{method:'POST',headers:{'Content-Type':'application/json'},body: JSON.stringify({character_id:newChar.character_id})});
+          } catch(e){}
+          window.location.href = '/play';
         }catch(e){ alert(e.message || 'Create failed'); }
       });
     }

--- a/templates/characters.html
+++ b/templates/characters.html
@@ -18,7 +18,7 @@
     <div class="title">Choose Your Character</div>
     <div class="row">
       <a class="btn ghost" href="/class-builder">Class Builder</a>
-      <a class="btn ghost" href="/mvp">Play (current)</a>
+      <a class="btn ghost" href="/play">Play</a>
       <a class="btn" href="/character-create">+ Create New</a>
     </div>
   </header>
@@ -54,7 +54,7 @@
           try{
             if(act==='play'){
               await api('/api/game/characters/select',{method:'POST',headers:{'Content-Type':'application/json'}, body: JSON.stringify({character_id:id})});
-              window.location.href = '/mvp';
+              window.location.href = '/play';
             }else if(act==='delete'){
               if(confirm('Delete this character?')){
                 await api(`/api/game/characters/${id}`,{method:'DELETE'});

--- a/templates/class_builder.html
+++ b/templates/class_builder.html
@@ -44,7 +44,7 @@
     <div class="title">Class Builder</div>
     <nav class="actions">
       <a class="btn ghost" href="/characters">Characters</a>
-      <a class="btn" href="/mvp">Play</a>
+      <a class="btn" href="/play">Play</a>
     </nav>
   </header>
 


### PR DESCRIPTION
## Summary
- Add `/play` route serving the MVP3 game client
- Redirect character select/create flows to `/play` and auto-select new characters
- Update docs and in-app links to point at `/play`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bba2423254832da02183c81dacbdca