### PR TITLE
Refactor client v2 layout and modular UI

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -191,7 +191,7 @@ def create_app():
 
     @app.route("/play")
     def play():
-        return render_template("mvp3.html")
+        return render_template("client_v2.html")
 
     @app.route("/api-playground")
     def api_playground():

--- a/client/css/client_v2.css
+++ b/client/css/client_v2.css
@@ -1,141 +1,144 @@
-/* Layout for Shardbound client v2 */
+/* client_v2.css
+   Minimal layout for paperdoll, inventory, map viewport and console.
+*/
 
 body {
+  margin: 0;
   display: grid;
-  grid-template-columns: 340px 1fr 80px 300px;
-  grid-template-rows: auto 1fr;
-  min-height: 100vh;
-  background: #1c1a17;
+  grid-template-columns: 240px 1fr 240px;
+  grid-template-rows: 1fr 160px;
+  grid-template-areas:
+    "left center right"
+    "console console console";
+  height: 100vh;
+  background: var(--bg);
   color: var(--text);
-  font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, serif;
+  font-family: ui-sans-serif, system-ui, sans-serif;
 }
 
-body.sidebar-collapsed {
-  grid-template-columns: 0 1fr 80px 300px;
-}
-
-header {
-  grid-column: 1 / -1;
-}
-
-#clientSidebar {
-  grid-row: 2;
-  grid-column: 1;
-  width: 340px;
-  padding: 16px;
+#panel-left {
+  grid-area: left;
+  padding: 8px;
   background: var(--panel);
   border-right: 1px solid var(--line);
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
   overflow-y: auto;
-  transition: transform .2s ease;
 }
 
-#clientSidebar.collapsed {
-  transform: translateX(-100%);
-}
-
-#btnSidebarCollapse {
-  position: absolute;
-  top: 8px;
-  right: -12px;
-  width: 24px;
-  height: 24px;
-}
-
-main.viewerMain {
-  grid-row: 2;
-  grid-column: 2;
-  padding: 16px;
+#viewport {
+  grid-area: center;
   display: flex;
-  flex-direction: column;
   align-items: center;
+  justify-content: center;
+  background: var(--bg);
 }
 
-#actionRail {
-  grid-row: 2;
-  grid-column: 3;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  align-items: center;
-  padding: 16px 8px;
-  position: sticky;
-  top: 0;
-  height: 100vh;
-}
-
-#rightSidebar {
-  grid-row: 2;
-  grid-column: 4;
-  width: 300px;
-  padding: 16px;
+#panel-right {
+  grid-area: right;
+  padding: 8px;
   background: var(--panel);
   border-left: 1px solid var(--line);
+  overflow-y: auto;
+  font-size: 14px;
+}
+
+#console {
+  grid-area: console;
   display: flex;
   flex-direction: column;
-  gap: 20px;
-  overflow-y: auto;
-}
-
-.panel-body {
-  font-size: 14px;
-  line-height: 1.4;
-}
-
-#actionRail button {
-  width: 60px;
-  height: 60px;
-  border-radius: 50%;
-}
-
-#shardStatus {
-  font-size: 12px;
-  color: var(--muted);
-}
-
-.console-section {
-  margin-top: 16px;
   background: var(--panel);
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+  border-top: 1px solid var(--line);
+}
+
+#console-log {
+  flex: 1;
+  padding: 4px;
+  overflow-y: auto;
+  font-family: ui-monospace, monospace;
+}
+
+#console-input {
+  padding: 6px;
+  border: none;
+  background: var(--bg);
   color: var(--text);
 }
 
-.console-section summary {
-  padding: 8px;
-  cursor: pointer;
+.paperdoll {
+  display: grid;
+  grid-template-columns: repeat(3, 64px);
+  grid-auto-rows: 64px;
+  gap: 4px;
+  margin-bottom: 8px;
 }
 
-.console-section #console-root {
+.equip-slot {
+  width: 64px;
+  height: 64px;
+  border: 1px solid var(--line);
+  background: var(--bg);
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
+}
+
+.inventory-grid {
+  display: grid;
+  grid-template-columns: repeat(5, 64px);
+  gap: 4px;
+}
+
+.inventory-grid .cell {
+  width: 64px;
+  height: 64px;
+  border: 1px solid var(--line);
+  background: var(--bg);
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
+  position: relative;
+}
+
+.inventory-grid .stack {
+  position: absolute;
+  bottom: 2px;
+  right: 4px;
+  background: rgba(0,0,0,0.6);
+  padding: 0 2px;
+  font-size: 12px;
+}
+
+#quick-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+#quick-actions button {
+  padding: 8px;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--line);
+}
+
+#tile-json {
+  background: var(--bg);
+  border: 1px solid var(--line);
+  padding: 4px;
   max-height: 200px;
-  overflow-y: auto;
-  padding: 8px;
+  overflow: auto;
 }
 
-@media (max-width: 900px) {
-  body {
-    grid-template-columns: 0 1fr 60px 0;
-  }
-  body.sidebar-collapsed {
-    grid-template-columns: 0 1fr 60px 0;
-  }
-  body.sidebar-collapsed #clientSidebar {
-    transform: translateX(-100%);
-  }
-  #clientSidebar {
-    transform: translateX(-100%);
-  }
-  #clientSidebar:not(.collapsed) {
-    transform: translateX(0);
-  }
-  #actionRail {
-    grid-column: 3;
-    padding: 8px 4px;
-  }
-  #rightSidebar {
-    display: none;
-  }
+#tile-form {
+  width: 100%;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--line);
 }
+
+.tile-buttons {
+  display: flex;
+  gap: 4px;
+  margin-top: 4px;
+}
+

--- a/client/js/consoleUI.js
+++ b/client/js/consoleUI.js
@@ -1,0 +1,30 @@
+/* consoleUI.js
+   Minimal scrollable console with command input.
+   Public events: dispatches 'console:command'; listens for 'console:log'.
+*/
+
+const logEl = document.getElementById('console-log');
+const input = document.getElementById('console-input');
+
+function log(msg) {
+  const line = document.createElement('div');
+  line.textContent = msg;
+  logEl.appendChild(line);
+  logEl.scrollTop = logEl.scrollHeight;
+}
+
+document.addEventListener('console:log', (e) => log(e.detail));
+
+input.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter') {
+    const cmd = input.value.trim();
+    if (cmd) {
+      log('> ' + cmd);
+      document.dispatchEvent(new CustomEvent('console:command', { detail: cmd }));
+      input.value = '';
+    }
+  }
+});
+
+log('Console ready');
+

--- a/client/js/inventory.js
+++ b/client/js/inventory.js
@@ -1,0 +1,86 @@
+/* inventory.js
+   Renders the inventory grid and manages drag/drop reordering and unequip.
+   Public events: dispatches 'inventory:add', 'inventory:unequip';
+   listens for 'equip:changed'.
+*/
+
+const grid = document.getElementById('inventory-grid');
+
+let inventory = [
+  { id: 'wooden_sword', name: 'Wooden Sword', slot: 'mainhand', icon: '/static/assets/items/wooden_sword.png', qty: 1 },
+  { id: 'bread', name: 'Bread', slot: null, icon: '/static/assets/items/bread.png', qty: 3 },
+  { id: 'health_potion', name: 'Health Potion', slot: null, icon: '/static/assets/items/health_potion.png', qty: 2 }
+];
+
+function render() {
+  grid.innerHTML = '';
+  inventory.forEach((item, idx) => {
+    const cell = document.createElement('div');
+    cell.className = 'cell';
+    cell.draggable = true;
+    cell.dataset.index = idx;
+    cell.style.backgroundImage = `url(${item.icon})`;
+    cell.title = item.name;
+    if (item.qty > 1) {
+      const stack = document.createElement('span');
+      stack.className = 'stack';
+      stack.textContent = item.qty;
+      cell.appendChild(stack);
+    }
+
+    cell.addEventListener('dragstart', (e) => {
+      e.dataTransfer.setData('text/plain', JSON.stringify({ ...item, index: idx, from: 'inventory' }));
+    });
+
+    cell.addEventListener('dragover', (e) => e.preventDefault());
+    cell.addEventListener('drop', (e) => {
+      e.preventDefault();
+      const data = JSON.parse(e.dataTransfer.getData('text/plain'));
+      if (data.from === 'inventory') {
+        const from = data.index;
+        const to = idx;
+        const [moved] = inventory.splice(from, 1);
+        inventory.splice(to, 0, moved);
+        render();
+      } else if (data.from === 'paperdoll') {
+        inventory.splice(idx, 0, data);
+        render();
+        document.dispatchEvent(new CustomEvent('inventory:unequip', { detail: { slot: data.slot } }));
+      }
+    });
+
+    grid.appendChild(cell);
+  });
+}
+
+grid.addEventListener('dragover', (e) => e.preventDefault());
+grid.addEventListener('drop', (e) => {
+  e.preventDefault();
+  const text = e.dataTransfer.getData('text/plain');
+  if (!text) return;
+  const data = JSON.parse(text);
+  if (data.from === 'paperdoll') {
+    inventory.push(data);
+    render();
+    document.dispatchEvent(new CustomEvent('inventory:unequip', { detail: { slot: data.slot } }));
+  }
+});
+
+document.addEventListener('inventory:add', (e) => {
+  inventory.push(e.detail);
+  render();
+});
+
+document.addEventListener('equip:changed', (e) => {
+  const { item, previous } = e.detail;
+  if (item.from === 'inventory') {
+    inventory = inventory.filter((_, i) => i !== item.index);
+  }
+  if (previous) {
+    inventory.push(previous);
+  }
+  render();
+});
+
+render();
+

--- a/client/js/mapViewport.js
+++ b/client/js/mapViewport.js
@@ -1,0 +1,87 @@
+/* mapViewport.js
+   Simple 32x32 tile map with zoom, pan, hover and select events.
+   Public events: dispatches 'map:hover' and 'map:select'.
+*/
+
+const canvas = document.getElementById('map-canvas');
+const ctx = canvas.getContext('2d');
+const tileSize = 32;
+let zoom = 1;
+let offsetX = 0;
+let offsetY = 0;
+
+const width = 20;
+const height = 15;
+const tiles = [];
+for (let y = 0; y < height; y++) {
+  const row = [];
+  for (let x = 0; x < width; x++) {
+    row.push({ type: (x + y) % 2 === 0 ? 'grass' : 'water' });
+  }
+  tiles.push(row);
+}
+
+function draw() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  const size = tileSize * zoom;
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const t = tiles[y][x];
+      ctx.fillStyle = t.type === 'grass' ? '#3a5' : '#35a';
+      ctx.fillRect(offsetX + x * size, offsetY + y * size, size, size);
+      ctx.strokeStyle = 'rgba(0,0,0,0.2)';
+      ctx.strokeRect(offsetX + x * size, offsetY + y * size, size, size);
+    }
+  }
+}
+
+function tileFromEvent(e) {
+  const rect = canvas.getBoundingClientRect();
+  const size = tileSize * zoom;
+  const x = Math.floor((e.clientX - rect.left - offsetX) / size);
+  const y = Math.floor((e.clientY - rect.top - offsetY) / size);
+  if (x >= 0 && y >= 0 && x < width && y < height) {
+    return { x, y, ...tiles[y][x] };
+  }
+  return null;
+}
+
+let dragging = false;
+let lastX = 0;
+let lastY = 0;
+
+canvas.addEventListener('mousedown', (e) => {
+  dragging = true;
+  lastX = e.clientX;
+  lastY = e.clientY;
+});
+
+canvas.addEventListener('mousemove', (e) => {
+  if (dragging) {
+    offsetX += e.clientX - lastX;
+    offsetY += e.clientY - lastY;
+    lastX = e.clientX;
+    lastY = e.clientY;
+    draw();
+  }
+  const tile = tileFromEvent(e);
+  if (tile) document.dispatchEvent(new CustomEvent('map:hover', { detail: tile }));
+});
+
+canvas.addEventListener('mouseup', () => (dragging = false));
+canvas.addEventListener('mouseleave', () => (dragging = false));
+
+canvas.addEventListener('wheel', (e) => {
+  e.preventDefault();
+  const delta = e.deltaY < 0 ? 0.1 : -0.1;
+  zoom = Math.min(3, Math.max(0.5, zoom + delta));
+  draw();
+});
+
+canvas.addEventListener('click', (e) => {
+  const tile = tileFromEvent(e);
+  if (tile) document.dispatchEvent(new CustomEvent('map:select', { detail: tile }));
+});
+
+draw();
+

--- a/client/js/paperdoll.js
+++ b/client/js/paperdoll.js
@@ -1,0 +1,66 @@
+/* paperdoll.js
+   Builds equipment slots and handles equip/unequip via drag & drop.
+   Public events: dispatches 'equip:changed'; listens for 'inventory:unequip'.
+*/
+
+const slots = ['head','cloak','chest','belt','pants','boots','mainhand','offhand','jewelry','gadget'];
+const equipment = {
+  chest: { id: 'leather_jerkin', name: 'Leather Jerkin', slot: 'chest', icon: '/static/assets/items/leather_jerkin.png', qty: 1 },
+  mainhand: { id: 'iron_sword', name: 'Iron Sword', slot: 'mainhand', icon: '/static/assets/items/iron_sword.png', qty: 1 },
+  offhand: { id: 'buckler', name: 'Buckler', slot: 'offhand', icon: '/static/assets/items/buckler.png', qty: 1 }
+};
+
+const doll = document.getElementById('paperdoll');
+
+slots.forEach(slot => {
+  const cell = document.createElement('div');
+  cell.className = 'equip-slot';
+  cell.dataset.slot = slot;
+  cell.draggable = true;
+  updateCell(cell, equipment[slot]);
+
+  cell.addEventListener('dragstart', e => {
+    const item = equipment[slot];
+    if (!item) { e.preventDefault(); return; }
+    e.dataTransfer.setData('text/plain', JSON.stringify({ ...item, from: 'paperdoll', slot }));
+  });
+
+  cell.addEventListener('dragover', e => e.preventDefault());
+  cell.addEventListener('drop', e => {
+    e.preventDefault();
+    const data = JSON.parse(e.dataTransfer.getData('text/plain'));
+    if (data.slot && data.slot === slot) {
+      const previous = equipment[slot] || null;
+      equipment[slot] = { ...data };
+      updateCell(cell, data);
+      document.dispatchEvent(new CustomEvent('equip:changed', { detail: { slot, item: data, previous } }));
+    } else {
+      cell.classList.add('reject');
+      setTimeout(() => cell.classList.remove('reject'), 300);
+    }
+  });
+
+  doll.appendChild(cell);
+});
+
+function updateCell(cell, item) {
+  if (item) {
+    cell.style.backgroundImage = `url(${item.icon})`;
+    cell.title = item.name;
+  } else {
+    cell.style.backgroundImage = '';
+    cell.removeAttribute('title');
+  }
+}
+
+document.addEventListener('inventory:unequip', e => {
+  const { slot } = e.detail;
+  equipment[slot] = null;
+  const cell = doll.querySelector(`.equip-slot[data-slot="${slot}"]`);
+  if (cell) updateCell(cell, null);
+});
+
+export function getEquipment() {
+  return equipment;
+}
+

--- a/client/js/tileInfoPanel.js
+++ b/client/js/tileInfoPanel.js
@@ -1,0 +1,49 @@
+/* tileInfoPanel.js
+   Displays selected tile JSON and exposes dev editing controls.
+   Public events: dispatches 'tile:apply' and 'tile:push'; listens for 'map:select'.
+*/
+
+const pre = document.getElementById('tile-json');
+const formWrap = document.getElementById('tile-form-wrap');
+const textarea = document.getElementById('tile-form');
+const btnValidate = document.getElementById('btn-validate');
+const btnApply = document.getElementById('btn-apply');
+const btnPush = document.getElementById('btn-push');
+
+const devMode = true;
+if (devMode) formWrap.hidden = false;
+
+document.addEventListener('map:select', (e) => {
+  const tile = e.detail;
+  const json = JSON.stringify(tile, null, 2);
+  pre.textContent = json;
+  textarea.value = json;
+});
+
+btnValidate?.addEventListener('click', () => {
+  try {
+    JSON.parse(textarea.value);
+    alert('Valid JSON');
+  } catch (err) {
+    alert('Invalid JSON');
+  }
+});
+
+btnApply?.addEventListener('click', () => {
+  try {
+    const data = JSON.parse(textarea.value);
+    document.dispatchEvent(new CustomEvent('tile:apply', { detail: data }));
+  } catch (err) {
+    alert('Invalid JSON');
+  }
+});
+
+btnPush?.addEventListener('click', () => {
+  try {
+    const data = JSON.parse(textarea.value);
+    document.dispatchEvent(new CustomEvent('tile:push', { detail: data }));
+  } catch (err) {
+    alert('Invalid JSON');
+  }
+});
+

--- a/client/templates/client_v2.html
+++ b/client/templates/client_v2.html
@@ -4,114 +4,53 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Shardbound Client v2</title>
-
-  <!-- Base styles + v2 overlay styles -->
-  <link rel="stylesheet" href="/static/css/shard-viewer.css" />
   <link rel="stylesheet" href="/static/css/shard-viewer-v2.css" />
-  <link rel="stylesheet" href="/static/css/inventoryOverlay.css" />
-  <link rel="stylesheet" href="/static/css/characterPanel.css" />
   <link rel="stylesheet" href="/static/css/client_v2.css" />
-
-  <script>
-    window.SHARDBIOME_SOURCE = 'grid';
-  </script>
 </head>
 <body>
-  <header>
-    <h1 id="shardName">Shard</h1>
-    <span id="shardStatus">—</span>
-  </header>
-
-  <aside id="clientSidebar">
-    <button id="btnSidebarCollapse" aria-label="Collapse sidebar">◀</button>
-    <section class="card" id="cardCharacter">
-      <h2>Character</h2>
-      <div class="hud" id="charHud" style="margin:10px 0;">
-        <div class="bar hp"><span>HP</span><i id="statHP" style="width:80%"></i></div>
-        <div class="bar mp"><span>MP</span><i id="statMP" style="width:60%"></i></div>
-        <div class="bar sta"><span>STA</span><i id="statSTA" style="width:90%"></i></div>
-      </div>
-      <div class="dim" id="statHunger" style="font-size:12px;margin-bottom:10px;">Hunger: 0</div>
-      <div class="char-grid">
-        <div class="char-col">
-          <h3>Equipment</h3>
-          <ul class="slots">
-            <li><span>Head</span><i>—</i></li>
-            <li><span>Chest</span><i>Leather Jerkin</i></li>
-            <li><span>Main-hand</span><i>Rusty Blade</i></li>
-            <li><span>Off-hand</span><i>Buckler</i></li>
-            <li><span>Ring</span><i>Copper Band</i></li>
-          </ul>
-        </div>
-        <div class="char-col">
-          <h3>Stats</h3>
-          <ul class="stats">
-            <li>STR 10</li><li>AGI 9</li><li>INT 8</li><li>STA 12</li>
-            <li>Armor 4</li><li>Crit 2%</li>
-          </ul>
-        </div>
-      </div>
-    </section>
-    <section class="card" id="cardInventory">
-      <h2 id="invHeaderTitle">Inventory (0)</h2>
-      <div id="invPanelMount" class="inv-mount" aria-live="polite"></div>
-    </section>
-  </aside>
-
-  <main class="viewerMain">
-    <section class="card viewer">
-      <h2>Map</h2>
-      <section class="canvas-wrap" id="frame">
-        <canvas id="canvas"></canvas>
-        <div class="tooltip" id="tooltip"></div>
-        <div class="debug-badge" id="debugBadge" aria-live="polite" style="opacity:0"></div>
-        <div class="zoomOverlay">
-          <button class="zbtn" id="btnFit" title="Fit (refit)">⤢</button>
-          <button class="zbtn" id="btnZoomIn" title="Zoom in">+</button>
-          <button class="zbtn" id="btnZoomOut" title="Zoom out">−</button>
-        </div>
-      </section>
-      <details id="consoleSection" class="console-section" open>
-        <summary>Console</summary>
-        <div id="console-root" aria-live="polite"></div>
-      </details>
-    </section>
-  </main>
-
-  <div id="actionRail">
-    <button id="btnLook">Look</button>
-    <button id="btnInteract">Interact</button>
-    <button id="btnRest">Rest</button>
-    <button id="btnSkill1">Skill 1</button>
-    <button id="btnSkill2">Skill 2</button>
+  <div id="panel-left">
+    <div id="paperdoll" class="paperdoll"></div>
+    <div id="inventory" class="inventory">
+      <div id="inventory-grid" class="inventory-grid"></div>
+    </div>
   </div>
 
-  <aside id="rightSidebar">
-    <section class="card" id="cardQuestLog">
-      <h2>Quest Log</h2>
-      <div class="panel-body" id="questLog">No quests available.</div>
-    </section>
-    <section class="card" id="cardJournal">
-      <h2>Journal</h2>
-      <div class="panel-body" id="journal">Your thoughts go here.</div>
-    </section>
-    <section class="card" id="cardPlaceholder">
-      <h2>Mysteries</h2>
-      <div class="panel-body" id="placeholder">Nothing here yet.</div>
-    </section>
-  </aside>
+  <div id="viewport">
+    <canvas id="map-canvas" width="640" height="480"></canvas>
+  </div>
 
-  <div id="action-root" class="action-root"></div>
+  <div id="panel-right">
+    <div id="quick-actions">
+      <button data-action="look">Look</button>
+      <button data-action="interact">Interact</button>
+      <button data-action="rest">Rest</button>
+      <button data-action="slot1">Action 1</button>
+      <button data-action="slot2">Action 2</button>
+    </div>
+    <div id="tile-info">
+      <h3>Tile Info</h3>
+      <pre id="tile-json">{}</pre>
+      <div id="tile-form-wrap" hidden>
+        <textarea id="tile-form" rows="6"></textarea>
+        <div class="tile-buttons">
+          <button id="btn-validate">Validate</button>
+          <button id="btn-apply">Apply</button>
+          <button id="btn-push">Push Live</button>
+        </div>
+      </div>
+    </div>
+  </div>
 
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      if (window.matchMedia('(max-width: 900px)').matches) {
-        document.body.classList.add('sidebar-collapsed');
-        document.getElementById('clientSidebar')?.classList.add('collapsed');
-        document.getElementById('consoleSection')?.removeAttribute('open');
-      }
-    });
-  </script>
-  <script type="module" src="/static/js/client_v2.js"></script>
+  <div id="console">
+    <div id="console-log"></div>
+    <input id="console-input" type="text" placeholder="Command..." />
+  </div>
+
+  <script type="module" src="/static/js/paperdoll.js"></script>
+  <script type="module" src="/static/js/inventory.js"></script>
+  <script type="module" src="/static/js/mapViewport.js"></script>
+  <script type="module" src="/static/js/tileInfoPanel.js"></script>
+  <script type="module" src="/static/js/consoleUI.js"></script>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- Serve `client_v2.html` from `/play`
- Rebuild client v2 layout with paperdoll, inventory, map viewport, tile info panel and console
- Add modular JS for drag/drop equipment, map interaction and console log

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bcc6a5f77c832d85cf48840bd64e98