### PR TITLE
Add top banner and map viewer upgrades

### DIFF
--- a/client/css/client_v2.css
+++ b/client/css/client_v2.css
@@ -44,8 +44,9 @@ body {
   margin: 0;
   display: grid;
   grid-template-columns: 280px 1fr 300px;
-  grid-template-rows: 1fr 180px;
+  grid-template-rows: auto 1fr 180px;
   grid-template-areas:
+    "topbar topbar topbar"
     "left center right"
     "console console console";
   height: 100vh;
@@ -68,6 +69,7 @@ body::after {
 }
 #panel-left  { grid-area: left;  border-right: 1px solid var(--line); }
 #panel-right { grid-area: right; border-left:  1px solid var(--line); }
+#topbar { grid-area: topbar; display: flex; gap: 12px; }
 
 #viewport {
   grid-area: center;

--- a/client/templates/client_v2.html
+++ b/client/templates/client_v2.html
@@ -13,9 +13,14 @@
 
   <!-- v2 map viewer styles + client layout -->
   <link rel="stylesheet" href="{{ url_for('static', filename='css/shard-viewer-v2.css') }}" />
-  <link rel="stylesheet" href="{{ url_for('static', filename='css/client_v2.css') }}" />
+<link rel="stylesheet" href="{{ url_for('static', filename='css/client_v2.css') }}" />
 </head>
 <body class="theme-fantasy">
+  <nav id="topbar" class="card">
+    <a href="/forums">Forums</a>
+    <a href="/account">Account</a>
+    <a id="linkDevTools" href="/dev" style="display:none">Dev Tools</a>
+  </nav>
   <!-- LEFT: Character + Inventory (single expanded card, no scrolling) -->
   <aside id="panel-left">
     <section class="card" id="cardCharacter">
@@ -65,6 +70,7 @@
           <button class="zbtn" id="btnFit" title="Fit (refit)">⤢</button>
           <button class="zbtn" id="btnZoomIn" title="Zoom in">+</button>
           <button class="zbtn" id="btnZoomOut" title="Zoom out">−</button>
+          <button class="zbtn" id="btnCenter" title="Player not placed yet" disabled>◎</button>
         </div>
         <div id="tooltip" class="tooltip"></div>
       </section>


### PR DESCRIPTION
## Summary
- Add top navigation bar with conditional Dev Tools link for admins
- Fit shard map to frame and increase base tile scale to 50px with wider zoom bounds
- Render and center player token with new control to re-center on current tile
- Fix top banner layout and ensure mouse-wheel zoom works across map

## Testing
- `npm test` (fails: Missing script)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd04548aec832d98d8ea83b8d862dc