### PR TITLE
Add character equipment system with service and API

### DIFF
--- a/api/characters.py
+++ b/api/characters.py
@@ -1,9 +1,11 @@
 # app/characters.py
 import json
 from pathlib import Path
-from flask import Blueprint, jsonify, render_template, redirect
+from flask import Blueprint, jsonify, render_template, redirect, request
 from flask_login import login_required
-from .models import db
+from .models import db, Character
+from services.equipment import get_loadout, equip_item, unequip_slot, EquipError
+from services.derived_stats import build_snapshot
 
 characters_bp = Blueprint("characters_bp", __name__)
 
@@ -87,3 +89,46 @@ def active_character():
 @login_required
 def autosave_state():
     return jsonify(error="deprecated; use /api/game/characters/autosave"), 410
+
+
+# ----- equipment endpoints -----
+
+@characters_bp.get("/api/characters/<string:character_id>/loadout")
+def loadout(character_id: str):
+    char = Character.query.get(character_id)
+    if not char:
+        return jsonify(error="not_found"), 404
+    if not char.combat_snapshot:
+        char.combat_snapshot = build_snapshot(character_id)
+        db.session.commit()
+    return jsonify(get_loadout(character_id))
+
+
+@characters_bp.post("/api/characters/<string:character_id>/equip")
+def api_equip(character_id: str):
+    data = request.get_json() or {}
+    try:
+        dto = equip_item(character_id=character_id, item_instance_id=data.get("item_instance_id"), slot=data.get("slot"))
+    except EquipError as e:
+        return jsonify(error=e.code), 409
+    return jsonify(dto)
+
+
+@characters_bp.post("/api/characters/<string:character_id>/unequip")
+def api_unequip(character_id: str):
+    data = request.get_json() or {}
+    try:
+        dto = unequip_slot(character_id=character_id, slot=data.get("slot"))
+    except EquipError as e:
+        return jsonify(error=e.code), 409
+    return jsonify(dto)
+
+
+@characters_bp.post("/api/characters/<string:character_id>/recompute")
+def api_recompute(character_id: str):
+    char = Character.query.get(character_id)
+    if not char:
+        return jsonify(error="not_found"), 404
+    char.combat_snapshot = build_snapshot(character_id)
+    db.session.commit()
+    return jsonify(get_loadout(character_id))

--- a/api/models/__init__.py
+++ b/api/models/__init__.py
@@ -5,6 +5,7 @@ from .users import User                      # noqa: F401
 from .characters import Character            # noqa: F401
 from .items import Item                      # noqa: F401
 from .inventory import ItemInstance, CharacterInventory   # noqa: F401
+from .equipment import CharacterEquipped, EQUIP_SLOTS  # noqa: F401
 from .item import Item as ItemV1             # noqa: F401
 from .inventory_item import InventoryItem    # noqa: F401
 from .inventory_v2 import StarterLoadout, CharacterItem  # noqa: F401
@@ -18,7 +19,7 @@ from .audit import AdminAuditLog  # noqa: F401
 __all__ = [
     "db", "Model", "metadata",
     "User", "Character",
-    "Item", "ItemInstance", "CharacterInventory",
+    "Item", "ItemInstance", "CharacterInventory", "CharacterEquipped", "EQUIP_SLOTS",
     "ItemV1", "InventoryItem", "StarterLoadout", "CharacterItem",
     "Town", "TownRoom", "NPC", "Quest", "QuestState", "CharacterState", "EncounterTrigger",
     "AdminAuditLog",

--- a/api/models/characters.py
+++ b/api/models/characters.py
@@ -1,6 +1,7 @@
 import uuid, datetime as dt
 
 from .base import db, Model
+from .equipment import CharacterEquipped
 
 
 def gen_uuid() -> str:
@@ -32,6 +33,7 @@ class Character(Model):
 
     # easy-mode state bucket (inventory, quests, flags) -> normalize later
     state = db.Column(db.JSON)
+    combat_snapshot = db.Column(db.JSON)
 
     # legacy compatibility: some databases still have an `is_deleted` column
     # defined as NOT NULL; include it with a default to satisfy inserts.
@@ -50,3 +52,12 @@ class Character(Model):
         back_populates="character",
         cascade="all, delete-orphan",
     )
+    equipped_items = db.relationship(
+        "CharacterEquipped",
+        back_populates="character",
+        lazy="select",
+        cascade="all, delete-orphan",
+    )
+
+    def get_equipped_map(self):
+        return {ce.slot: ce.item_instance for ce in self.equipped_items}

--- a/api/models/equipment.py
+++ b/api/models/equipment.py
@@ -1,0 +1,34 @@
+import datetime as dt
+from sqlalchemy.orm import validates
+from sqlalchemy import UniqueConstraint, ForeignKey
+
+from .base import db, Model
+
+EQUIP_SLOTS = [
+    "head","chest","legs","feet","hands","main_hand","off_hand",
+    "neck","ring1","ring2","belt","back"
+]
+
+class CharacterEquipped(Model):
+    __tablename__ = "character_equipped"
+
+    id = db.Column(db.Integer, primary_key=True)
+    character_id = db.Column(db.String(64), ForeignKey("character.character_id", ondelete="CASCADE"), nullable=False, index=True)
+    slot = db.Column(db.String(32), nullable=False, index=True)
+    item_instance_id = db.Column(db.String(64), ForeignKey("item_instances.instance_id"), nullable=False, unique=True)
+    created_at = db.Column(db.DateTime, default=dt.datetime.utcnow, nullable=False)
+    updated_at = db.Column(db.DateTime, default=dt.datetime.utcnow, onupdate=dt.datetime.utcnow, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint("character_id", "slot", name="uq_character_equipped_slot"),
+    )
+
+    character = db.relationship("Character", back_populates="equipped_items")
+    item_instance = db.relationship("ItemInstance")
+
+    @validates("slot")
+    def validate_slot(self, key, value):
+        if value not in EQUIP_SLOTS:
+            raise ValueError("invalid slot")
+        return value
+

--- a/migrations/versions/43f9d88c2c2e_character_equipped.py
+++ b/migrations/versions/43f9d88c2c2e_character_equipped.py
@@ -1,0 +1,45 @@
+"""character_equipped table and combat_snapshot column
+
+Revision ID: 43f9d88c2c2e
+Revises: fe12c3a4b9a3
+Create Date: 2025-09-05
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '43f9d88c2c2e'
+down_revision = 'fe12c3a4b9a3'
+branch_labels = None
+depends_on = None
+
+
+def _json_type():
+    bind = op.get_bind()
+    if bind.dialect.name == 'postgresql':
+        from sqlalchemy.dialects.postgresql import JSONB
+        return JSONB
+    return sa.JSON
+
+
+def upgrade() -> None:
+    json_type = _json_type()
+    op.add_column('character', sa.Column('combat_snapshot', json_type, nullable=True))
+    op.create_table(
+        'character_equipped',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('character_id', sa.String(length=64), sa.ForeignKey('character.character_id', ondelete='CASCADE'), nullable=False),
+        sa.Column('slot', sa.String(length=32), nullable=False),
+        sa.Column('item_instance_id', sa.String(length=64), sa.ForeignKey('item_instances.instance_id'), nullable=False, unique=True),
+        sa.Column('created_at', sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), server_default=sa.func.now(), onupdate=sa.func.now(), nullable=False),
+        sa.UniqueConstraint('character_id', 'slot', name='uq_character_equipped_slot')
+    )
+    op.create_index('ix_character_equipped_character_id', 'character_equipped', ['character_id'])
+    op.create_index('ix_character_equipped_slot', 'character_equipped', ['slot'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_character_equipped_slot', table_name='character_equipped')
+    op.drop_index('ix_character_equipped_character_id', table_name='character_equipped')
+    op.drop_table('character_equipped')
+    op.drop_column('character', 'combat_snapshot')

--- a/seeds/dev_seed_equipment.py
+++ b/seeds/dev_seed_equipment.py
@@ -1,0 +1,39 @@
+"""Minimal seed for equipment demo"""
+from api import create_app
+from api.models import db, User, Character, Item, ItemInstance, CharacterItem, CharacterEquipped
+
+def run():
+    app = create_app()
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        user = User(user_id="user1", email="demo@example.com", password_hash="x", display_name="Demo")
+        db.session.add(user)
+        char = Character(name="Hero", user_id=user.user_id)
+        db.session.add(char)
+        # templates
+        sword = Item(item_id="sword", item_version="1", name="Sword", type="weapon", rarity="common", stats={"attack": 3}, slot="main_hand")
+        shield = Item(item_id="shield", item_version="1", name="Shield", type="armor", rarity="common", stats={"armor": 2}, slot="off_hand")
+        helm = Item(item_id="helm", item_version="1", name="Helm", type="armor", rarity="common", stats={"armor": 1}, slot="head")
+        ring = Item(item_id="ring", item_version="1", name="Ring", type="trinket", rarity="common", stats={"crit_chance": 1}, slot="ring1")
+        chest = Item(item_id="chest", item_version="1", name="Chest", type="armor", rarity="common", stats={"armor": 3}, slot="chest")
+        db.session.add_all([sword, shield, helm, ring, chest])
+        # instances
+        inst1 = ItemInstance(instance_id="sword1", item_id="sword", item_version="1")
+        inst2 = ItemInstance(instance_id="shield1", item_id="shield", item_version="1")
+        inst3 = ItemInstance(instance_id="helm1", item_id="helm", item_version="1")
+        inst4 = ItemInstance(instance_id="ring1", item_id="ring", item_version="1")
+        inst5 = ItemInstance(instance_id="chest1", item_id="chest", item_version="1")
+        db.session.add_all([inst1, inst2, inst3, inst4, inst5])
+        # ownership
+        for item in [sword, shield, helm, ring, chest]:
+            db.session.add(CharacterItem(character_id=char.character_id, item_id=item.item_id, quantity=1))
+        db.session.commit()
+        # pre-equip sword
+        ce = CharacterEquipped(character_id=char.character_id, slot="main_hand", item_instance_id="sword1")
+        db.session.add(ce)
+        db.session.commit()
+        print("Seeded character", char.character_id)
+
+if __name__ == "__main__":
+    run()

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,1 @@
+# service package

--- a/services/derived_stats.py
+++ b/services/derived_stats.py
@@ -1,0 +1,58 @@
+import hashlib
+import logging
+from typing import Dict, Any
+
+from api.models import db, CharacterEquipped, ItemInstance, Item
+
+logger = logging.getLogger(__name__)
+
+
+def compute_derived_stats(character_id: str) -> Dict[str, Any]:
+    rows = (
+        db.session.query(CharacterEquipped)
+        .filter_by(character_id=character_id)
+        .all()
+    )
+    totals: Dict[str, float] = {}
+    effects = []
+    ids = []
+    for ce in rows:
+        inst = ItemInstance.query.get(ce.item_instance_id)
+        if not inst:
+            continue
+        tmpl = Item.query.get(inst.item_id)
+        ids.append(ce.item_instance_id)
+        stats = getattr(tmpl, "stats", {}) or {}
+        tags = getattr(tmpl, "tags", []) or []
+        for stat, val in stats.items():
+            try:
+                num = float(val)
+            except Exception:
+                continue
+            totals[stat] = totals.get(stat, 0) + num
+            effects.append({
+                "id": f"{tmpl.item_id}:{stat}",
+                "scope": "character",
+                "stat": stat,
+                "op": "add",
+                "value": num,
+                "tags": tags,
+                "duration": "passive",
+            })
+    return {"stats": totals, "effects": effects}
+
+
+def build_snapshot(character_id: str) -> Dict[str, Any]:
+    data = compute_derived_stats(character_id)
+    ids = sorted(
+        ce.item_instance_id for ce in db.session.query(CharacterEquipped).filter_by(character_id=character_id)
+    )
+    sources_hash = hashlib.sha1(";".join(ids).encode()).hexdigest() if ids else ""
+    data["sources_hash"] = sources_hash
+    logger.info(
+        "snapshot_rebuild character_id=%s sources_hash=%s changed_stats_count=%s",
+        character_id,
+        sources_hash,
+        len(data.get("stats", {})),
+    )
+    return data

--- a/services/equipment.py
+++ b/services/equipment.py
@@ -1,0 +1,125 @@
+import logging
+from typing import Dict, Any
+from sqlalchemy.orm import joinedload
+
+from api.models import (
+    db,
+    Character,
+    ItemInstance,
+    Item,
+    CharacterItem,
+    CharacterEquipped,
+    EQUIP_SLOTS,
+)
+from .derived_stats import build_snapshot
+
+logger = logging.getLogger(__name__)
+
+class EquipError(Exception):
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+def get_loadout(character_id: str) -> Dict[str, Any]:
+    char = (
+        Character.query.options(
+            joinedload(Character.equipped_items).joinedload(CharacterEquipped.item_instance)
+        ).get(character_id)
+    )
+    if not char:
+        return {}
+    equipped: Dict[str, Any] = {}
+    for ce in char.equipped_items:
+        tmpl = Item.query.get(ce.item_instance.item_id) if ce.item_instance else None
+        equipped[ce.slot] = {
+            "item_instance_id": ce.item_instance_id,
+            "template_id": ce.item_instance.item_id if ce.item_instance else None,
+            "name": tmpl.name if tmpl else None,
+        }
+    inventory = []
+    rows = CharacterItem.query.filter_by(character_id=character_id).all()
+    for row in rows:
+        itm = Item.query.get(row.item_id)
+        inventory.append({
+            "item_instance_id": None,
+            "template_id": row.item_id,
+            "name": itm.name if itm else None,
+            "qty": row.quantity,
+        })
+    return {
+        "equipped": equipped,
+        "inventory": inventory,
+        "derived_stats": (char.combat_snapshot or {}).get("stats", {}),
+    }
+
+
+def equip_item(*, character_id: str, item_instance_id: str, slot: str) -> Dict[str, Any]:
+    if slot not in EQUIP_SLOTS:
+        raise EquipError("E_SLOT_INVALID", "Invalid slot")
+    try:
+        char = Character.query.get(character_id)
+        if not char:
+            raise EquipError("E_NO_CHAR", "Character not found")
+        inst = ItemInstance.query.get(item_instance_id)
+        if not inst:
+            raise EquipError("E_NO_ITEM", "Item instance not found")
+        owned = CharacterItem.query.filter_by(character_id=character_id, item_id=inst.item_id).first()
+        if not owned:
+            raise EquipError("E_NOT_OWNER", "Character does not own item")
+        tmpl = Item.query.get(inst.item_id)
+        allowed = getattr(tmpl, "allowed_slots", None) or ([tmpl.slot] if getattr(tmpl, "slot", None) else [])
+        if allowed and slot not in allowed:
+            raise EquipError("E_SLOT_INVALID", "Item not allowed in slot")
+        prev = CharacterEquipped.query.filter_by(character_id=character_id, slot=slot).first()
+        replaced_id = None
+        if prev:
+            replaced_id = prev.item_instance_id
+            db.session.delete(prev)
+        other = CharacterEquipped.query.filter_by(item_instance_id=item_instance_id).first()
+        if other:
+            db.session.delete(other)
+        ce = CharacterEquipped(character_id=character_id, slot=slot, item_instance_id=item_instance_id)
+        db.session.add(ce)
+        snapshot = build_snapshot(character_id)
+        char.combat_snapshot = snapshot
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        raise
+    logger.info(
+        "equip_item character_id=%s slot=%s new_item_instance_id=%s replaced_item_instance_id=%s",
+        character_id,
+        slot,
+        item_instance_id,
+        replaced_id,
+    )
+    return get_loadout(character_id)
+
+
+def unequip_slot(*, character_id: str, slot: str) -> Dict[str, Any]:
+    if slot not in EQUIP_SLOTS:
+        raise EquipError("E_SLOT_INVALID", "Invalid slot")
+    try:
+        char = Character.query.get(character_id)
+        if not char:
+            raise EquipError("E_NO_CHAR", "Character not found")
+        prev = CharacterEquipped.query.filter_by(character_id=character_id, slot=slot).first()
+        removed_id = None
+        if prev:
+            removed_id = prev.item_instance_id
+            db.session.delete(prev)
+        snapshot = build_snapshot(character_id)
+        char.combat_snapshot = snapshot
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        raise
+    logger.info(
+        "unequip_slot character_id=%s slot=%s removed_item_instance_id=%s",
+        character_id,
+        slot,
+        removed_id,
+    )
+    return get_loadout(character_id)

--- a/tests/test_equipment_api.py
+++ b/tests/test_equipment_api.py
@@ -1,0 +1,36 @@
+from api import create_app
+from api.models import db, User, Character, Item, ItemInstance, CharacterItem
+
+def build_app():
+    app = create_app()
+    with app.app_context():
+        db.drop_all(); db.create_all()
+        u = User(user_id="u1", email="a@a")
+        db.session.add(u)
+        c = Character(name="Hero", user_id=u.user_id)
+        db.session.add(c)
+        db.session.flush()
+        tmpl = Item(item_id="sword", item_version="1", name="Sword", type="weapon", rarity="common", stats={"attack":1}, slot="main_hand")
+        db.session.add(tmpl)
+        inst = ItemInstance(instance_id="inst1", item_id="sword", item_version="1")
+        db.session.add(inst)
+        db.session.add(CharacterItem(character_id=c.character_id, item_id="sword", quantity=1))
+        db.session.commit()
+        return app, c.character_id, inst.instance_id
+
+
+def test_api_flow():
+    app, cid, inst = build_app()
+    with app.test_client() as client:
+        r = client.get(f"/api/characters/{cid}/loadout")
+        assert r.status_code == 200
+        r = client.post(f"/api/characters/{cid}/equip", json={"item_instance_id": inst, "slot": "main_hand"})
+        assert r.status_code == 200
+        data = r.get_json()
+        assert data["equipped"]["main_hand"]["item_instance_id"] == inst
+        r = client.post(f"/api/characters/{cid}/unequip", json={"slot": "main_hand"})
+        assert r.status_code == 200
+        data = r.get_json()
+        assert "main_hand" not in data["equipped"]
+        r = client.post(f"/api/characters/{cid}/recompute")
+        assert r.status_code == 200

--- a/tests/test_equipment_constraints.py
+++ b/tests/test_equipment_constraints.py
@@ -1,0 +1,54 @@
+import pytest
+from api import create_app
+from api.models import db, User, Character, Item, ItemInstance, CharacterItem, CharacterEquipped
+import sqlalchemy as sa
+
+
+def prepare_app():
+    app = create_app()
+    with app.app_context():
+        db.drop_all(); db.create_all()
+        user = User(user_id="u", email="x@x")
+        db.session.add(user)
+        char = Character(name="Hero", user_id=user.user_id)
+        db.session.add(char)
+        db.session.flush()
+        item = Item(item_id="itm", item_version="1", name="Itm", type="weapon", rarity="common", stats={}, slot="main_hand")
+        db.session.add(item)
+        inst = ItemInstance(instance_id="inst", item_id="itm", item_version="1")
+        db.session.add(inst)
+        db.session.add(CharacterItem(character_id=char.character_id, item_id=item.item_id, quantity=1))
+        cid = char.character_id
+        iid = inst.instance_id
+        db.session.commit()
+    return app, cid, iid
+
+
+def test_unique_constraints_and_cascade():
+    app, cid, inst_id = prepare_app()
+    with app.app_context():
+        ce1 = CharacterEquipped(character_id=cid, slot="main_hand", item_instance_id=inst_id)
+        db.session.add(ce1)
+        db.session.commit()
+        # duplicate slot should violate
+        ce2 = CharacterEquipped(character_id=cid, slot="main_hand", item_instance_id="other")
+        db.session.add(ce2)
+        with pytest.raises(sa.exc.IntegrityError):
+            db.session.commit()
+        db.session.rollback()
+        # duplicate item_instance_id across characters
+        user2 = User(user_id="u2", email="b@b")
+        db.session.add(user2)
+        char2 = Character(name="Other", user_id=user2.user_id)
+        db.session.add(char2)
+        db.session.flush()
+        db.session.commit()
+        ce3 = CharacterEquipped(character_id=char2.character_id, slot="off_hand", item_instance_id=inst_id)
+        db.session.add(ce3)
+        with pytest.raises(sa.exc.IntegrityError):
+            db.session.commit()
+        db.session.rollback()
+        # cascade delete
+        db.session.delete(Character.query.get(cid))
+        db.session.commit()
+        assert db.session.query(CharacterEquipped).filter_by(character_id=cid).count() == 0

--- a/tests/test_equipment_service.py
+++ b/tests/test_equipment_service.py
@@ -1,0 +1,69 @@
+import pytest
+
+from api import create_app
+from api.models import db, User, Character, Item, ItemInstance, CharacterItem
+from services.equipment import equip_item, unequip_slot, EquipError
+from services.derived_stats import build_snapshot
+
+
+def setup_data():
+    app = create_app()
+    with app.app_context():
+        db.drop_all(); db.create_all()
+        user = User(user_id="u1", email="e@e")
+        db.session.add(user)
+        char = Character(name="Hero", user_id=user.user_id)
+        db.session.add(char)
+        db.session.flush()
+        sword = Item(item_id="sword", item_version="1", name="Sword", type="weapon", rarity="common", stats={"attack": 5}, slot="main_hand")
+        axe = Item(item_id="axe", item_version="1", name="Axe", type="weapon", rarity="common", stats={"attack": 7}, slot="main_hand")
+        db.session.add_all([sword, axe])
+        inst1 = ItemInstance(instance_id="inst1", item_id="sword", item_version="1")
+        inst2 = ItemInstance(instance_id="inst2", item_id="axe", item_version="1")
+        db.session.add_all([inst1, inst2])
+        db.session.add(CharacterItem(character_id=char.character_id, item_id="sword", quantity=1))
+        db.session.add(CharacterItem(character_id=char.character_id, item_id="axe", quantity=1))
+        db.session.commit()
+        return app, char.character_id, inst1.instance_id, inst2.instance_id
+
+
+def test_non_owner_rejected():
+    app = create_app()
+    with app.app_context():
+        db.drop_all(); db.create_all()
+        user1 = User(user_id="u1", email="a@a")
+        user2 = User(user_id="u2", email="b@b")
+        db.session.add_all([user1, user2])
+        char1 = Character(name="Hero1", user_id=user1.user_id)
+        char2 = Character(name="Hero2", user_id=user2.user_id)
+        db.session.add_all([char1, char2])
+        db.session.flush()
+        sword = Item(item_id="sword", item_version="1", name="Sword", type="weapon", rarity="common", stats={}, slot="main_hand")
+        db.session.add(sword)
+        inst = ItemInstance(instance_id="inst1", item_id="sword", item_version="1")
+        db.session.add(inst)
+        db.session.add(CharacterItem(character_id=char2.character_id, item_id="sword", quantity=1))
+        db.session.commit()
+        with pytest.raises(EquipError):
+            equip_item(character_id=char1.character_id, item_instance_id=inst.instance_id, slot="main_hand")
+
+
+def test_equip_replace_and_unequip():
+    app, cid, inst1, inst2 = setup_data()
+    with app.app_context():
+        dto = equip_item(character_id=cid, item_instance_id=inst1, slot="main_hand")
+        assert dto["equipped"]["main_hand"]["item_instance_id"] == inst1
+        dto = equip_item(character_id=cid, item_instance_id=inst2, slot="main_hand")
+        assert dto["equipped"]["main_hand"]["item_instance_id"] == inst2
+        dto = unequip_slot(character_id=cid, slot="main_hand")
+        assert "main_hand" not in dto["equipped"]
+
+
+def test_snapshot_changes():
+    app, cid, inst1, inst2 = setup_data()
+    with app.app_context():
+        equip_item(character_id=cid, item_instance_id=inst1, slot="main_hand")
+        snap1 = build_snapshot(cid)["sources_hash"]
+        equip_item(character_id=cid, item_instance_id=inst2, slot="main_hand")
+        snap2 = build_snapshot(cid)["sources_hash"]
+        assert snap1 != snap2


### PR DESCRIPTION
## Summary
- add `character_equipped` table and combat snapshot column
- implement `CharacterEquipped` ORM, equipment services and derived stat snapshot
- expose loadout/equip/unequip/recompute API endpoints and seed script

## Testing
- `pytest tests/test_equipment_service.py -q`
- `pytest tests/test_equipment_constraints.py -q`
- `pytest tests/test_equipment_api.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bd94fa0950832daf10402872fbc031