### PR TITLE
Adjust canvas wrap sizing and add player token overlay

### DIFF
--- a/client/css/client_v2.css
+++ b/client/css/client_v2.css
@@ -136,7 +136,7 @@ body::after {
 
 /* ====== MAP FRAME (ornate “wood”) ====== */
 .canvas-wrap {
-  width: 720px; height: 540px;   /* keep your viewer sizing */
+  display: inline-block;
   background:
     linear-gradient(180deg,#1b1a23,#0e0d13);
   border-radius: 14px;

--- a/client/css/shard-viewer-v2.css
+++ b/client/css/shard-viewer-v2.css
@@ -9,9 +9,7 @@
   border: 1px solid var(--line);
   border-radius: 10px;
   overflow: hidden;
-  /* Fixed map box size */
-  width: 720px;
-  height: 540px;
+  display: inline-block; /* shrink to map size */
 }
 
 /* Both canvases: absolutely fill the wrap */

--- a/client/css/shard-viewer.css
+++ b/client/css/shard-viewer.css
@@ -61,7 +61,7 @@ header h1{ margin:0; font-size:16px; font-weight:700; color:#aee6ff; letter-spac
   mix-blend-mode: overlay; border-radius:10px;
 }
 
-.zoomOverlay{ position:absolute; top:10px; right:10px; display:flex; flex-direction:column; gap:8px; z-index:2 }
+.zoomOverlay{ position:absolute; top:10px; right:10px; display:flex; flex-direction:column; gap:8px; z-index:20 }
 .zbtn{
   width:var(--zoom-size); height:var(--zoom-size); display:grid; place-items:center; font-weight:900;
   font-size:calc(var(--zoom-size)*.6); background:#0b1430; color:#d6eeff; border:1px solid #26457a; border-radius:8px;

--- a/client/js/client_v2.js
+++ b/client/js/client_v2.js
@@ -224,6 +224,19 @@ function startAutosave() {
   // Always lock frame & disable wheel to satisfy “edge to edge, no zoom”
   lockViewerFrameEdgeToEdge();
 
+  try {
+    const state = await API.spawn();
+    const pos = state?.player?.pos;
+    if (Array.isArray(pos)) {
+      Viewer.setPlayerPos?.(pos[0], pos[1]);
+      Viewer.centerOnTile?.(pos[0], pos[1]);
+      const cBtn = document.getElementById('btnCenter');
+      if (cBtn) { cBtn.disabled = false; cBtn.title = 'Center on player'; }
+    }
+  } catch (err) {
+    console.warn('Player spawn failed', err);
+  }
+
   // HUD and actions
   try {
     if (document.querySelector('.room-stage')) {

--- a/client/js/shard-viewer-lite.js
+++ b/client/js/shard-viewer-lite.js
@@ -62,7 +62,7 @@ document.body.appendChild(tip);
 
 const dpr = () => window.devicePixelRatio || 1;
 // Default to a 35px tile scale if no control is present
-const scale = () => Math.max(1, parseInt(els.scale?.value || '50', 10));
+const scale = () => Math.max(1, parseInt(els.scale?.value || '32', 10));
 const alpha = () => Math.max(0, Math.min(1, (parseInt(els.opacity?.value || '85', 10) || 85) / 100));
 
 // State
@@ -139,6 +139,10 @@ function ensureSizes(W, H) {
     overlay.height = H * s;
     overlay.style.width = `${W * s}px`;
     overlay.style.height = `${H * s}px`;
+    if (els.frame) {
+      els.frame.style.width = `${W * s}px`;
+      els.frame.style.height = `${H * s}px`;
+    }
   }
 }
 function applyPan() {
@@ -430,6 +434,7 @@ els.frame?.addEventListener('wheel', handleWheel, { passive: false });
 $('btnZoomIn')?.addEventListener('click', (e) => { e?.preventDefault?.(); const rect = els.frame.getBoundingClientRect(); zoomAt(rect.width / 2, rect.height / 2, 1.2); });
 $('btnZoomOut')?.addEventListener('click', (e) => { e?.preventDefault?.(); const rect = els.frame.getBoundingClientRect(); zoomAt(rect.width / 2, rect.height / 2, 0.8); });
 $('btnFit')?.addEventListener('click', (e) => { e?.preventDefault?.(); fitToFrame(); });
+$('btnCenter')?.addEventListener('click', (e) => { e?.preventDefault?.(); if (Number.isFinite(ST.playerPos.x) && Number.isFinite(ST.playerPos.y)) centerOnTile(ST.playerPos.x, ST.playerPos.y); });
 
 // Layer controls
 els.scale?.addEventListener('input', () => { if (!ST.grid) return; ensureSizes(ST.grid[0]?.length || 0, ST.grid.length || 0); scheduleDraw(); });
@@ -443,4 +448,9 @@ els.palette?.addEventListener('change', () => scheduleDraw());
 
 // public API
 export function currentShard() { return ST.shard; }
-export function setPlayerPos(x, y) { ST.playerPos = { x, y }; scheduleDraw(); }
+export function setPlayerPos(x, y) {
+  ST.playerPos = { x, y };
+  const c = $('btnCenter');
+  if (c) { c.disabled = false; c.title = 'Center on player'; }
+  scheduleDraw();
+}

--- a/client/templates/shard-viewer-v2.html
+++ b/client/templates/shard-viewer-v2.html
@@ -59,7 +59,7 @@
 
         <div class="group">
           <h3>Viewer</h3>
-          <div class="row"><label>Scale (px/tile)</label><input id="scale" type="number" min="1" max="64" value="8" /></div>
+          <div class="row"><label>Scale (px/tile)</label><input id="scale" type="number" min="1" max="64" value="32" /></div>
           <div class="row"><label>Show grid</label><input id="grid" type="checkbox" checked /></div>
           <div class="row"><label>Auto-fit</label><input id="autoFit" type="checkbox" checked /></div>
           <div class="row"><label>CRT scanlines</label><input id="crtMode" type="checkbox" /></div>
@@ -130,6 +130,7 @@
           <button class="zbtn" id="btnFit" title="Fit (refit)">⤢</button>
           <button class="zbtn" id="btnZoomIn" title="Zoom in">+</button>
           <button class="zbtn" id="btnZoomOut" title="Zoom out">−</button>
+          <button class="zbtn" id="btnCenter" title="Player not placed yet" disabled>◎</button>
         </div>
       </section>
       <section>


### PR DESCRIPTION
## Summary
- Shrink canvas wrappers to map dimensions and raise zoom overlay above canvases
- Add center button and player token rendering with auto loading on login
- Spawn player and center map on login

## Testing
- `pytest` *(fails: OperationalError and other failures)*

------
https://chatgpt.com/codex/tasks/task_e_68beca1533e0832d9d92e9e3071aab7a