### PR TITLE
Enhance client-v2 layout and actions

### DIFF
--- a/client/css/client_v2.css
+++ b/client/css/client_v2.css
@@ -41,16 +41,26 @@ body{
 }
 
 /* Layout rails (kept lean; adapt to your markup) */
-#panel-left,#panel-right,#viewport,#topbar,#console-root{
+#panel-left,#panel-right,#viewport,#topbar{
   border:1px solid var(--line);
   border-radius: 12px;
   background: linear-gradient(180deg, #0d0c13, #0b0a11);
   box-shadow: 0 6px 18px rgba(0,0,0,.4), inset 0 1px 0 rgba(255,255,255,.03);
 }
 #topbar{padding:8px 10px;display:flex;gap:10px;margin:8px}
-#panel-left,#panel-right{padding:10px;margin:8px}
-#viewport{padding:10px;margin:8px}
-#console-root{padding:10px;margin:8px;font-family: ui-monospace, monospace;min-height:110px}
+
+/* three‑column layout wrapper */
+#layout{display:flex;gap:8px;margin:0 8px 8px;}
+#panel-left,#panel-right,#viewport{margin:0;}
+#panel-left,#panel-right{padding:10px;flex:0 0 auto;}
+#viewport{
+  padding:10px;
+  flex:1;
+  min-width:0;
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+}
 
 /* Cards */
 .card{
@@ -86,13 +96,20 @@ body{
 /* ================= */
 /* MAP CANVAS FRAME  */
 /* ================= */
+.viewer-row{display:flex;gap:12px;align-items:flex-start}
 .canvas-wrap{
-  display:inline-block;
+  display:flex;
+  flex-direction:column;
+  flex:1;
   background: linear-gradient(180deg,#1b1a23,#0e0d13);
-  border-radius:14px;border:1px solid var(--line);
-  box-shadow: 0 10px 30px rgba(0,0,0,.5), inset 0 0 0 2px rgba(255,255,255,.03);
   position:relative;
 }
+.canvas-wrap canvas{flex:1;}
+.action-dock{width:200px;flex-shrink:0}
+.console-card{width:100%;}
+.char-grid{display:flex;flex-direction:column;gap:16px}
+.paperdoll{flex-shrink:0;align-self:center}
+.inv-embed{flex:0 0 auto}
 .zoomOverlay .zbtn{
   width:32px;height:32px;line-height:32px;text-align:center;
   border-radius:8px;border:1px solid var(--line);
@@ -180,18 +197,18 @@ body{
 }
 .paperdoll-stage{
   position:relative;
-  display:grid;
-  grid-template-columns: 1fr;
-  grid-auto-rows: auto;
-  gap:12px;
-  place-items:center;
+  width:calc(var(--slot)*4 + var(--gap)*3);
+  height:calc(var(--slot)*4 + var(--gap)*3);
 }
 
 /* Doll image with subtle halo */
 .doll-image{
+  position:absolute;
+  left:50%; top:50%; transform:translate(-50%,-50%);
   max-width:180px; max-height:220px;
   image-rendering:pixelated; pointer-events:none;
   filter: drop-shadow(0 8px 18px rgba(0,0,0,.45));
+  z-index:1;
 }
 .paperdoll-stage::before{
   content:"";
@@ -210,7 +227,9 @@ body{
   grid-template-columns: repeat(4, var(--slot));
   grid-template-rows: repeat(4, var(--slot));
   gap: var(--gap);
-  position:relative;
+  position:absolute;
+  top:0; left:0;
+  z-index:2;
 }
 
 /* Equip slot visuals */

--- a/client/js/client_v2.js
+++ b/client/js/client_v2.js
@@ -118,13 +118,13 @@ function ensureMoveButtons() {
     wrap.innerHTML = `
       <div style="display:grid;grid-template-columns:repeat(3,36px);grid-auto-rows:36px;gap:6px;justify-content:center;margin-top:8px;">
         <span></span>
-        <button id="btnMoveN"  title="North">N</button>
+        <button id="btnMoveN"  class="btn" title="North">N</button>
         <span></span>
-        <button id="btnMoveW"  title="West">W</button>
-        <button id="btnMoveC"  title="Center" disabled>·</button>
-        <button id="btnMoveE"  title="East">E</button>
+        <button id="btnMoveW"  class="btn" title="West">W</button>
+        <button id="btnMoveC"  class="btn" title="Center" disabled>·</button>
+        <button id="btnMoveE"  class="btn" title="East">E</button>
         <span></span>
-        <button id="btnMoveS"  title="South">S</button>
+        <button id="btnMoveS"  class="btn" title="South">S</button>
         <span></span>
       </div>`;
     dock.appendChild(wrap);

--- a/client/templates/client_v2.html
+++ b/client/templates/client_v2.html
@@ -21,32 +21,35 @@
     <a href="/account">Account</a>
     <a id="linkDevTools" href="/dev" style="display:none">Dev Tools</a>
   </nav>
+  <div id="layout">
   <!-- LEFT: Character + Inventory (single expanded card, no scrolling) -->
   <aside id="panel-left">
     <section class="card" id="cardCharacter">
       <header class="card-h">Character</header>
 
-      <!-- Two-column grid: paperdoll shrine + embedded inventory -->
+      <!-- Stacked layout: paperdoll shrine above embedded inventory -->
       <div class="char-grid">
         <!-- Paperdoll shrine -->
-        <div>
-          <div class="paperdoll-window">
+        <div class="paperdoll">
+          <div class="paperdoll-stage">
             <!-- Central doll image (replace src with your sprite path) -->
             <img class="doll-image"
                  src="/static/assets/character_models/placeholder_warrior.png"
                  alt="Character"
                  draggable="false" />
-            <!-- Slot scaffold; paperdoll.js will populate each .equip-slot -->
-            <div class="equip-slot" data-slot="head"      aria-label="Head"></div>
-            <div class="equip-slot" data-slot="cloak"     aria-label="Cloak"></div>
-            <div class="equip-slot" data-slot="chest"     aria-label="Chest"></div>
-            <div class="equip-slot" data-slot="belt"      aria-label="Belt"></div>
-            <div class="equip-slot" data-slot="pants"     aria-label="Pants"></div>
-            <div class="equip-slot" data-slot="boots"     aria-label="Boots"></div>
-            <div class="equip-slot" data-slot="mainhand"  aria-label="Main Hand"></div>
-            <div class="equip-slot" data-slot="offhand"   aria-label="Off Hand"></div>
-            <div class="equip-slot" data-slot="jewelry"   aria-label="Jewelry"></div>
-            <div class="equip-slot" data-slot="gadget"    aria-label="Gadget"></div>
+            <div class="paperdoll-grid">
+              <!-- Slot scaffold; paperdoll.js will populate each .equip-slot -->
+              <div class="equip-slot" data-slot="head"      aria-label="Head"></div>
+              <div class="equip-slot" data-slot="cloak"     aria-label="Cloak"></div>
+              <div class="equip-slot" data-slot="chest"     aria-label="Chest"></div>
+              <div class="equip-slot" data-slot="belt"      aria-label="Belt"></div>
+              <div class="equip-slot" data-slot="pants"     aria-label="Pants"></div>
+              <div class="equip-slot" data-slot="boots"     aria-label="Boots"></div>
+              <div class="equip-slot" data-slot="mainhand"  aria-label="Main Hand"></div>
+              <div class="equip-slot" data-slot="offhand"   aria-label="Off Hand"></div>
+              <div class="equip-slot" data-slot="jewelry"   aria-label="Jewelry"></div>
+              <div class="equip-slot" data-slot="gadget"    aria-label="Gadget"></div>
+            </div>
           </div>
         </div>
 
@@ -63,7 +66,8 @@
   <main id="viewport">
     <div class="viewer-row">
       <!-- Map frame -->
-      <section class="canvas-wrap" id="frame">
+      <section class="card canvas-wrap" id="frame">
+        <header class="card-h">Map</header>
         <canvas id="canvas"></canvas>
         <canvas id="overlayCanvasLite"></canvas>
         <div class="zoomOverlay">
@@ -80,23 +84,19 @@
         <header class="card-h">Actions</header>
         <div id="action-root"></div>
         <div class="quick-actions">
-          <button id="btnLook">Look</button>
-          <button id="btnInteract">Interact</button>
-          <button id="btnRest">Rest</button>
-          <button id="btnSkill1">Action 1</button>
-          <button id="btnSkill2">Action 2</button>
+          <button id="btnLook" class="btn">Look</button>
+          <button id="btnInteract" class="btn">Interact</button>
+          <button id="btnRest" class="btn">Rest</button>
+          <button id="btnSkill1" class="btn">Action 1</button>
+          <button id="btnSkill2" class="btn">Action 2</button>
         </div>
       </aside>
     </div>
 
     <!-- Console -->
     <section class="card console-card">
-
       <header class="card-h">Console</header>
-      <div id="console-root">
-        <div id="console-log" style="height:160px; overflow:auto; font: 13px/1.4 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; padding:8px; background:rgba(0,0,0,.35); border:1px solid rgba(255,255,255,.06); border-radius:6px;"></div>
-        <input id="console-input" placeholder="Type a command and press Enter" style="width:100%; margin-top:8px; padding:6px 8px; border-radius:6px; border:1px solid rgba(255,255,255,.08); background:rgba(0,0,0,.25); color:#ddd;">
-      </div>
+      <div id="console-root"></div>
     </section>
   </main>
 
@@ -121,6 +121,7 @@
       </div>
     </section>
   </aside>
+  </div>
 
   <!-- Scripts -->
   <script src="{{ url_for('static', filename='js/consoleUI.js') }}"></script>


### PR DESCRIPTION
## Summary
- Wrap client-v2 panels in a flex container to show character, map, and quest/journal panes side-by-side
- Stack character inventory below the paperdoll for clearer equipment display
- Maintain map header and action/console wiring for consistent gameplay UI

## Testing
- `npm test` *(fails: Missing script "test" [pre-existing])* 
- `pytest` *(fails: sqlite3.OperationalError: no such table: users)*

------
https://chatgpt.com/codex/tasks/task_e_68bee348b0f0832d8560f01215ad34dd