### PR TITLE
feat: persist user ui layout across sessions

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -21,6 +21,7 @@ from .security import admin_guard
 from .admin_panel import admin_ui
 from .api_inventory import bp as inventory_api_bp
 from .api.api_console import api_console
+from .ui_layout_api import ui_layout_api, limiter as ui_limiter
 
 # ----------------------
 # Helpers & utilities
@@ -170,6 +171,9 @@ def create_app():
     app.register_blueprint(admin_ui)
     app.register_blueprint(inventory_api_bp)
     app.register_blueprint(api_console, url_prefix="/api/console")
+    if ui_limiter:
+        ui_limiter.init_app(app)
+    app.register_blueprint(ui_layout_api, url_prefix="/api/ui")
 
     # Gameplay API
     try:

--- a/api/models/__init__.py
+++ b/api/models/__init__.py
@@ -14,6 +14,7 @@ from .gameplay import (
     Town, TownRoom, NPC, Quest, QuestState, CharacterState, EncounterTrigger,
 )  # noqa: F401
 from .audit import AdminAuditLog  # noqa: F401
+from .ui_layout import UserUILayout  # noqa: F401
 # from .crafting import Recipe               # noqa: F401
 
 __all__ = [
@@ -23,5 +24,6 @@ __all__ = [
     "ItemV1", "InventoryItem", "StarterLoadout", "CharacterItem",
     "Town", "TownRoom", "NPC", "Quest", "QuestState", "CharacterState", "EncounterTrigger",
     "AdminAuditLog",
+    "UserUILayout",
     # "Recipe",
 ]

--- a/api/models/ui_layout.py
+++ b/api/models/ui_layout.py
@@ -1,0 +1,10 @@
+import datetime as dt
+from .base import db, Model
+
+
+class UserUILayout(Model):
+    __tablename__ = "user_ui_layouts"
+
+    user_id = db.Column(db.String, db.ForeignKey("users.user_id"), primary_key=True)
+    layout = db.Column(db.JSON, nullable=False, default=dict)
+    updated_at = db.Column(db.DateTime, nullable=False, default=dt.datetime.utcnow, onupdate=dt.datetime.utcnow)

--- a/api/ui_layout_api.py
+++ b/api/ui_layout_api.py
@@ -1,0 +1,145 @@
+import datetime as dt
+from functools import wraps
+from typing import Dict, Literal
+
+from flask import Blueprint, request, jsonify, abort, session
+
+from .models import db, UserUILayout
+
+# ---- Auth helpers ---------------------------------------------------------
+try:  # Flask-Login preferred
+    from flask_login import current_user, login_required  # type: ignore
+
+    def get_current_user_id() -> str:
+        if not getattr(current_user, "is_authenticated", False):
+            abort(401)
+        return str(current_user.get_id())
+except Exception:  # pragma: no cover - flask_login not installed
+    def login_required(fn):  # type: ignore
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            if "user_id" not in session:
+                abort(401)
+            return fn(*args, **kwargs)
+        return wrapper
+
+    def get_current_user_id() -> str:
+        uid = session.get("user_id")
+        if not uid:
+            abort(401)
+        return str(uid)
+
+# ---- Rate limiter ---------------------------------------------------------
+try:  # pragma: no cover - optional dependency
+    from flask_limiter import Limiter
+    from flask_limiter.util import get_remote_address
+
+    limiter = Limiter(get_remote_address)
+except Exception:  # pragma: no cover - limiter not available
+    limiter = None  # type: ignore
+
+# ---- Validation schema ----------------------------------------------------
+from pydantic import (
+    BaseModel,
+    Field,
+    ValidationError,
+    ConfigDict,
+    constr,
+    conint,
+    confloat,
+    field_validator,
+)
+
+
+class SnapSchema(BaseModel):
+    mode: Literal["pixel", "cols"]
+    px: conint(ge=0, le=20000)
+    colW: conint(ge=0, le=20000)
+    model_config = ConfigDict(extra="forbid")
+
+
+class PanelSchema(BaseModel):
+    xPx: conint(ge=0, le=20000)
+    yPx: conint(ge=0, le=20000)
+    xPct: confloat(ge=0, le=100)
+    yPct: confloat(ge=0, le=100)
+    col: conint(ge=0, le=20000)
+    z: conint(ge=0, le=20000)
+    model_config = ConfigDict(extra="forbid")
+
+
+class LayoutSchema(BaseModel):
+    version: Literal[1]
+    mode: Literal["free", "docked"]
+    locked: bool
+    snap: SnapSchema
+    panels: Dict[constr(max_length=64), PanelSchema]
+    updatedAt: conint(ge=0, le=2 ** 63 - 1)
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("panels")
+    @classmethod
+    def _check_panels(cls, v: Dict[str, PanelSchema]):
+        if len(v) > 64:
+            raise ValueError("panels map too large")
+        return v
+
+
+# ---- Blueprint ------------------------------------------------------------
+ui_layout_api = Blueprint("ui_layout_api", __name__)
+
+
+def default_layout() -> dict:
+    return {}
+
+
+def _json_response(payload, status=200):
+    resp = jsonify(payload)
+    resp.status_code = status
+    resp.headers["Cache-Control"] = "no-store"
+    resp.headers["Content-Type"] = "application/json; charset=utf-8"
+    return resp
+
+
+@ui_layout_api.route("/layout", methods=["GET"])
+@login_required
+def get_layout():
+    user_id = get_current_user_id()
+    row = db.session.get(UserUILayout, user_id)
+    payload = row.layout if row else default_layout()
+    return _json_response(payload)
+
+
+@ui_layout_api.route("/layout", methods=["PUT"])
+@login_required
+def put_layout():
+    if request.content_type != "application/json":
+        abort(415)
+    if request.content_length and request.content_length > 64 * 1024:
+        abort(413)
+    try:
+        data = request.get_json(force=True)
+    except Exception:
+        abort(400)
+    try:
+        layout = LayoutSchema.model_validate(data)
+    except ValidationError as e:
+        return _json_response({"error": e.errors()}, status=400)
+
+    user_id = get_current_user_id()
+    row = db.session.get(UserUILayout, user_id)
+    if not row:
+        row = UserUILayout(user_id=user_id)
+    row.layout = layout.model_dump()
+    row.updated_at = dt.datetime.utcnow()
+    db.session.add(row)
+    db.session.commit()
+    return _json_response(row.layout)
+
+
+# apply rate limit if available
+if limiter:
+    put_layout = limiter.limit("60/minute")(put_layout)
+else:  # pragma: no cover
+    # TODO: add real rate limiting
+    pass

--- a/docs/ui_layout_api.md
+++ b/docs/ui_layout_api.md
@@ -1,0 +1,31 @@
+# UI Layout API
+
+Persist and retrieve the authenticated user's UI layout.
+
+### Sample Layout JSON
+```json
+{
+  "version": 1,
+  "mode": "free",
+  "locked": false,
+  "snap": { "mode": "pixel", "px": 8, "colW": 160 },
+  "panels": {
+    "chat": { "xPx": 0, "yPx": 0, "xPct": 0.0, "yPct": 0.0, "col": 0, "z": 0 }
+  },
+  "updatedAt": 1697040000000
+}
+```
+
+### Example Requests
+Fetch existing layout:
+```bash
+curl -X GET /api/ui/layout -b 'session=...'
+```
+
+Save new layout:
+```bash
+curl -X PUT /api/ui/layout \
+  -H 'Content-Type: application/json' \
+  -d '{"version":1,"mode":"free","locked":false,"snap":{"mode":"pixel","px":8,"colW":160},"panels":{"chat":{"xPx":0,"yPx":0,"xPct":0.0,"yPct":0.0,"col":0,"z":0}},"updatedAt":1697040000000}' \
+  -b 'session=...'
+```

--- a/migrations/versions/1c3e2b927a41_add_user_ui_layouts_table.py
+++ b/migrations/versions/1c3e2b927a41_add_user_ui_layouts_table.py
@@ -1,0 +1,30 @@
+"""add user_ui_layouts table"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "1c3e2b927a41"
+down_revision = "fe12c3a4b9a3"
+branch_labels = None
+depends_on = None
+
+
+def _json_type():
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        from sqlalchemy.dialects.postgresql import JSONB
+        return JSONB
+    return sa.JSON
+
+
+def upgrade() -> None:
+    json_type = _json_type()
+    op.create_table(
+        "user_ui_layouts",
+        sa.Column("user_id", sa.String(), sa.ForeignKey("users.user_id"), primary_key=True),
+        sa.Column("layout", json_type, nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("user_ui_layouts")


### PR DESCRIPTION
## Summary
- add UserUILayout model and migration
- expose GET and PUT /api/ui/layout endpoints
- document API with curl examples

## Testing
- `AUTO_CREATE_TABLES=1 pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf14f453ec832d8079c21714d0d99e