### PR TITLE
feat: add generic table listing helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ Users/Characters:
 - `users`, `user`, `characters`
 
 DB Inspection:
-- `tables`, `head`, `sql`, `export`
+- `tables` – list table names with row counts
+- `head <table>` – show rows from a table (`--limit`, `--id`, `--where`)
+- `sql`, `export`
 
 Items/Inventory:
 - `items`, `item`, `item-upsert`, `instances`, `mint`, `inventory`, `grant`,


### PR DESCRIPTION
## Summary
- add `tables` command to list all tables and row counts
- add `head` command to preview table rows with optional filters
- document table inspection helpers in README

## Testing
- `python db_cli.py tables`
- `python db_cli.py head users`
- `pytest` *(fails: tests/test_api_console.py::test_exec_echo_and_look, tests/test_api_console.py::test_rate_limit, tests/test_autosave_spawn.py::test_autosave_before_spawn_does_not_override_start, tests/test_character_location_persistence.py::test_cur_loc_updates_and_persists, tests/test_command_router.py::test_inv_returns_table_frame, tests/test_console_router.py::test_route_inv_returns_table)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1ce1c28c832db8673a05fd9092fc